### PR TITLE
Add detailed debugging hooks for mod lifecycle

### DIFF
--- a/src/main/java/com/xsasakihaise/hellasforms/HellasForms.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/HellasForms.java
@@ -18,6 +18,7 @@ import com.xsasakihaise.hellasforms.items.consumables.EvMaximizerItem;
 import com.xsasakihaise.hellasforms.items.consumables.ExperienceCandyItem;
 import com.xsasakihaise.hellasforms.items.consumables.RustedBottleCapItem;
 import com.xsasakihaise.hellasforms.items.heldItems.EeveeoliteItem;
+import com.xsasakihaise.hellasforms.diagnostics.DebuggingHooks;
 import com.xsasakihaise.hellasforms.listener.GrowthSpawningListener;
 import com.xsasakihaise.hellasforms.listener.ReturnItemsListener;
 import net.minecraft.item.Item;
@@ -58,178 +59,184 @@ public class HellasForms {
     }
 
     public HellasForms() {
-        instance = this;
-        IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
-        modEventBus.addListener(this::setup);
-        MinecraftForge.EVENT_BUS.register(this);
-        infoConfig = new HellasFormsInfoConfig();
-        infoConfig.loadDefaultsFromResource();
-        MinecraftForge.EVENT_BUS.addListener(this::onRegisterCommands);
+        DebuggingHooks.initialize(LOGGER);
+        DebuggingHooks.runWithTracing("HellasForms::<init>", LOGGER, () -> {
+            instance = this;
+            IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+            modEventBus.addListener(this::setup);
+            MinecraftForge.EVENT_BUS.register(this);
+            infoConfig = new HellasFormsInfoConfig();
+            infoConfig.loadDefaultsFromResource();
+            MinecraftForge.EVENT_BUS.addListener(this::onRegisterCommands);
 
-        EffectTypeAdapter.EFFECTS.put("ColonySwarm", ColonySwarm.class);
-        EffectTypeAdapter.EFFECTS.put("Corrode", Corrode.class);
-        EffectTypeAdapter.EFFECTS.put("GreekFire", GreekFire.class);
-        EffectTypeAdapter.EFFECTS.put("HitchKick", HitchKick.class);
-        EffectTypeAdapter.EFFECTS.put("PlasmaFangs", PlasmaFangs.class);
-        EffectTypeAdapter.EFFECTS.put("RabidClaw", RabidClaw.class);
-        EffectTypeAdapter.EFFECTS.put("PlasmaVeil", PlasmaVeil.class);
+            EffectTypeAdapter.EFFECTS.put("ColonySwarm", ColonySwarm.class);
+            EffectTypeAdapter.EFFECTS.put("Corrode", Corrode.class);
+            EffectTypeAdapter.EFFECTS.put("GreekFire", GreekFire.class);
+            EffectTypeAdapter.EFFECTS.put("HitchKick", HitchKick.class);
+            EffectTypeAdapter.EFFECTS.put("PlasmaFangs", PlasmaFangs.class);
+            EffectTypeAdapter.EFFECTS.put("RabidClaw", RabidClaw.class);
+            EffectTypeAdapter.EFFECTS.put("PlasmaVeil", PlasmaVeil.class);
 
-        EffectTypeAdapter.EFFECTS.put("RadiantEnergy", RadiantEnergy.class);
-        EffectTypeAdapter.EFFECTS.put("BleedingJaw", BleedingJaw.class);
-        EffectTypeAdapter.EFFECTS.put("Shatterstorm", Shatterstorm.class);
-        EffectTypeAdapter.EFFECTS.put("SnowstormFury", SnowstormFury.class);
-        EffectTypeAdapter.EFFECTS.put("Afterburner", Afterburner.class);
-        EffectTypeAdapter.EFFECTS.put("VenomAmbush", VenomAmbush.class);
-        EffectTypeAdapter.EFFECTS.put("DC", DC.class);
-        EffectTypeAdapter.EFFECTS.put("PhotonDarts", PhotonDarts.class);
-        EffectTypeAdapter.EFFECTS.put("SurgeBurrow", SurgeBurrow.class);
+            EffectTypeAdapter.EFFECTS.put("RadiantEnergy", RadiantEnergy.class);
+            EffectTypeAdapter.EFFECTS.put("BleedingJaw", BleedingJaw.class);
+            EffectTypeAdapter.EFFECTS.put("Shatterstorm", Shatterstorm.class);
+            EffectTypeAdapter.EFFECTS.put("SnowstormFury", SnowstormFury.class);
+            EffectTypeAdapter.EFFECTS.put("Afterburner", Afterburner.class);
+            EffectTypeAdapter.EFFECTS.put("VenomAmbush", VenomAmbush.class);
+            EffectTypeAdapter.EFFECTS.put("DC", DC.class);
+            EffectTypeAdapter.EFFECTS.put("PhotonDarts", PhotonDarts.class);
+            EffectTypeAdapter.EFFECTS.put("SurgeBurrow", SurgeBurrow.class);
 
-        EffectTypeAdapter.EFFECTS.put("TiroFinale", TiroFinale.class);
-        EffectTypeAdapter.EFFECTS.put("AuroraInfernalis", AuroraInfernalis.class);
-        EffectTypeAdapter.EFFECTS.put("StingingNettle", StingingNettle.class);
-        EffectTypeAdapter.EFFECTS.put("PetalBurst", PetalBurst.class);
-        EffectTypeAdapter.EFFECTS.put("Purification", Purification.class);
-        EffectTypeAdapter.EFFECTS.put("Thermodynamics", Thermodynamics.class);
-        EffectTypeAdapter.EFFECTS.put("IcyImmolation", IcyImmolation.class);
+            EffectTypeAdapter.EFFECTS.put("TiroFinale", TiroFinale.class);
+            EffectTypeAdapter.EFFECTS.put("AuroraInfernalis", AuroraInfernalis.class);
+            EffectTypeAdapter.EFFECTS.put("StingingNettle", StingingNettle.class);
+            EffectTypeAdapter.EFFECTS.put("PetalBurst", PetalBurst.class);
+            EffectTypeAdapter.EFFECTS.put("Purification", Purification.class);
+            EffectTypeAdapter.EFFECTS.put("Thermodynamics", Thermodynamics.class);
+            EffectTypeAdapter.EFFECTS.put("IcyImmolation", IcyImmolation.class);
 
-        ItemRegistration.ITEMS.register("eeveeolite", EeveeoliteItem::new);
+            ItemRegistration.ITEMS.register("eeveeolite", EeveeoliteItem::new);
 
-        ItemRegistration.ITEMS.register("diancite-hellas", () -> new MegaStoneItem("diancie form:hellas"));
-        ItemRegistration.ITEMS.register("sceptilite-hellas", () -> new MegaStoneItem("sceptile form:hellas"));
-        ItemRegistration.ITEMS.register("gyaradosite-hellas", () -> new MegaStoneItem("gyarados form:hellas"));
-        ItemRegistration.ITEMS.register("tyranitarite-hellas", () -> new MegaStoneItem("tyranitar form:hellas"));
-        ItemRegistration.ITEMS.register("gardevoirite-hellas", () -> new MegaStoneItem("gardevoir form:hellas"));
-        ItemRegistration.ITEMS.register("garchompite-hellas", () -> new MegaStoneItem("garchomp form:hellas"));
-        ItemRegistration.ITEMS.register("galladeite-hellas", () -> new MegaStoneItem("gallade form:hellas"));
-        ItemRegistration.ITEMS.register("samurottite-hellas", () -> new MegaStoneItem("samurott form:hellas"));
-        ItemRegistration.ITEMS.register("centiskorchite-hellas", () -> new MegaStoneItem("centiskorch form:hellas"));
-        ItemRegistration.ITEMS.register("aegislashite-hellas", () -> new MegaStoneItem("aegislash form:hellas"));
-        ItemRegistration.ITEMS.register("goodrite-hellas", () -> new MegaStoneItem("goodra form:hellas"));
+            ItemRegistration.ITEMS.register("diancite-hellas", () -> new MegaStoneItem("diancie form:hellas"));
+            ItemRegistration.ITEMS.register("sceptilite-hellas", () -> new MegaStoneItem("sceptile form:hellas"));
+            ItemRegistration.ITEMS.register("gyaradosite-hellas", () -> new MegaStoneItem("gyarados form:hellas"));
+            ItemRegistration.ITEMS.register("tyranitarite-hellas", () -> new MegaStoneItem("tyranitar form:hellas"));
+            ItemRegistration.ITEMS.register("gardevoirite-hellas", () -> new MegaStoneItem("gardevoir form:hellas"));
+            ItemRegistration.ITEMS.register("garchompite-hellas", () -> new MegaStoneItem("garchomp form:hellas"));
+            ItemRegistration.ITEMS.register("galladeite-hellas", () -> new MegaStoneItem("gallade form:hellas"));
+            ItemRegistration.ITEMS.register("samurottite-hellas", () -> new MegaStoneItem("samurott form:hellas"));
+            ItemRegistration.ITEMS.register("centiskorchite-hellas", () -> new MegaStoneItem("centiskorch form:hellas"));
+            ItemRegistration.ITEMS.register("aegislashite-hellas", () -> new MegaStoneItem("aegislash form:hellas"));
+            ItemRegistration.ITEMS.register("goodrite-hellas", () -> new MegaStoneItem("goodra form:hellas"));
 
-        ItemRegistration.ITEMS.register("bug_badge_hellas", BadgeItem::new);
-        ItemRegistration.ITEMS.register("dark_badge_hellas", BadgeItem::new);
-        ItemRegistration.ITEMS.register("dragon_badge_hellas", BadgeItem::new);
-        ItemRegistration.ITEMS.register("electric_badge_hellas", BadgeItem::new);
-        ItemRegistration.ITEMS.register("fairy_badge_hellas", BadgeItem::new);
-        ItemRegistration.ITEMS.register("fighting_badge_hellas", BadgeItem::new);
-        ItemRegistration.ITEMS.register("fire_badge_hellas", BadgeItem::new);
-        ItemRegistration.ITEMS.register("flying_badge_hellas", BadgeItem::new);
-        ItemRegistration.ITEMS.register("ghost_badge_hellas", BadgeItem::new);
-        ItemRegistration.ITEMS.register("grass_badge_hellas", BadgeItem::new);
-        ItemRegistration.ITEMS.register("ground_badge_hellas", BadgeItem::new);
-        ItemRegistration.ITEMS.register("ice_badge_hellas", BadgeItem::new);
-        ItemRegistration.ITEMS.register("normal_badge_hellas", BadgeItem::new);
-        ItemRegistration.ITEMS.register("poison_badge_hellas", BadgeItem::new);
-        ItemRegistration.ITEMS.register("psychic_badge_hellas", BadgeItem::new);
-        ItemRegistration.ITEMS.register("rock_badge_hellas", BadgeItem::new);
-        ItemRegistration.ITEMS.register("steel_badge_hellas", BadgeItem::new);
-        ItemRegistration.ITEMS.register("water_badge_hellas", BadgeItem::new);
+            ItemRegistration.ITEMS.register("bug_badge_hellas", BadgeItem::new);
+            ItemRegistration.ITEMS.register("dark_badge_hellas", BadgeItem::new);
+            ItemRegistration.ITEMS.register("dragon_badge_hellas", BadgeItem::new);
+            ItemRegistration.ITEMS.register("electric_badge_hellas", BadgeItem::new);
+            ItemRegistration.ITEMS.register("fairy_badge_hellas", BadgeItem::new);
+            ItemRegistration.ITEMS.register("fighting_badge_hellas", BadgeItem::new);
+            ItemRegistration.ITEMS.register("fire_badge_hellas", BadgeItem::new);
+            ItemRegistration.ITEMS.register("flying_badge_hellas", BadgeItem::new);
+            ItemRegistration.ITEMS.register("ghost_badge_hellas", BadgeItem::new);
+            ItemRegistration.ITEMS.register("grass_badge_hellas", BadgeItem::new);
+            ItemRegistration.ITEMS.register("ground_badge_hellas", BadgeItem::new);
+            ItemRegistration.ITEMS.register("ice_badge_hellas", BadgeItem::new);
+            ItemRegistration.ITEMS.register("normal_badge_hellas", BadgeItem::new);
+            ItemRegistration.ITEMS.register("poison_badge_hellas", BadgeItem::new);
+            ItemRegistration.ITEMS.register("psychic_badge_hellas", BadgeItem::new);
+            ItemRegistration.ITEMS.register("rock_badge_hellas", BadgeItem::new);
+            ItemRegistration.ITEMS.register("steel_badge_hellas", BadgeItem::new);
+            ItemRegistration.ITEMS.register("water_badge_hellas", BadgeItem::new);
 
-        ItemRegistration.ITEMS.register("rusted_bottle_cap", RustedBottleCapItem::new);
-        ItemRegistration.ITEMS.register("exp_candy_xxl", () -> new ExperienceCandyItem(60000, "item.pixelmon.exp_candy_xxl.success"));
-        ItemRegistration.ITEMS.register("exp_candy_xxxl", () -> new ExperienceCandyItem(120000, "item.pixelmon.exp_candy_xxxl.success"));
-        ItemRegistration.ITEMS.register("hp_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.hp(), "item.pixelmon.hp_252_ev_capsule.success"));
-        ItemRegistration.ITEMS.register("attack_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.attack(), "item.pixelmon.attack_252_ev_capsule.success"));
-        ItemRegistration.ITEMS.register("defense_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.defence(), "item.pixelmon.defense_252_ev_capsule.success"));
-        ItemRegistration.ITEMS.register("spatk_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.specialAttack(), "item.pixelmon.spatk_252_ev_capsule.success"));
-        ItemRegistration.ITEMS.register("spdef_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.specialDefence(), "item.pixelmon.spdef_252_ev_capsule.success"));
-        ItemRegistration.ITEMS.register("speed_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.speed(), "item.pixelmon.speed_252_ev_capsule.success"));
-        ItemRegistration.ITEMS.register("ability_patch_remover", AbilityPatchRemoverItem::new);
+            ItemRegistration.ITEMS.register("rusted_bottle_cap", RustedBottleCapItem::new);
+            ItemRegistration.ITEMS.register("exp_candy_xxl", () -> new ExperienceCandyItem(60000, "item.pixelmon.exp_candy_xxl.success"));
+            ItemRegistration.ITEMS.register("exp_candy_xxxl", () -> new ExperienceCandyItem(120000, "item.pixelmon.exp_candy_xxxl.success"));
+            ItemRegistration.ITEMS.register("hp_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.hp(), "item.pixelmon.hp_252_ev_capsule.success"));
+            ItemRegistration.ITEMS.register("attack_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.attack(), "item.pixelmon.attack_252_ev_capsule.success"));
+            ItemRegistration.ITEMS.register("defense_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.defence(), "item.pixelmon.defense_252_ev_capsule.success"));
+            ItemRegistration.ITEMS.register("spatk_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.specialAttack(), "item.pixelmon.spatk_252_ev_capsule.success"));
+            ItemRegistration.ITEMS.register("spdef_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.specialDefence(), "item.pixelmon.spdef_252_ev_capsule.success"));
+            ItemRegistration.ITEMS.register("speed_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.speed(), "item.pixelmon.speed_252_ev_capsule.success"));
+            ItemRegistration.ITEMS.register("ability_patch_remover", AbilityPatchRemoverItem::new);
 
-        ITEMS.register("wild-egg", PokemonEggItem::new);
-        ITEMS.register("hellasian-egg", PokemonEggItem::new);
-        ITEMS.register("odd-looking-egg", PokemonEggItem::new);
-        ITEMS.register("sparkly-wild-egg", PokemonEggItem::new);
-        ITEMS.register("sparkly-hellasian-egg", PokemonEggItem::new);
-        ITEMS.register("sparkly-odd-looking-egg", PokemonEggItem::new);
+            ITEMS.register("wild-egg", PokemonEggItem::new);
+            ITEMS.register("hellasian-egg", PokemonEggItem::new);
+            ITEMS.register("odd-looking-egg", PokemonEggItem::new);
+            ITEMS.register("sparkly-wild-egg", PokemonEggItem::new);
+            ITEMS.register("sparkly-hellasian-egg", PokemonEggItem::new);
+            ITEMS.register("sparkly-odd-looking-egg", PokemonEggItem::new);
 
-        for (int i = 1; i <= 20; i++) {
-            ITEMS.register("battlepass_item_" + i, BattlePassItem::new);
-        }
+            for (int i = 1; i <= 20; i++) {
+                ITEMS.register("battlepass_item_" + i, BattlePassItem::new);
+            }
 
-        ITEMS.register("hellas_adamantite", OreItem::new);
-        ITEMS.register("hellas_amazonite", OreItem::new);
-        ITEMS.register("hellas_amber", OreItem::new);
-        ITEMS.register("hellas_amethyst", OreItem::new);
-        ITEMS.register("hellas_ametrine", OreItem::new);
-        ITEMS.register("hellas_apatite", OreItem::new);
-        ITEMS.register("hellas_aquamarine", OreItem::new);
-        ITEMS.register("hellas_aventurine", OreItem::new);
-        ITEMS.register("hellas_azurite", OreItem::new);
-        ITEMS.register("hellas_blue_flourite", OreItem::new);
-        ITEMS.register("hellas_blue_quartz", OreItem::new);
-        ITEMS.register("hellas_blue_topaz", OreItem::new);
-        ITEMS.register("hellas_carnelian", OreItem::new);
-        ITEMS.register("hellas_chromite", OreItem::new);
-        ITEMS.register("hellas_chrysoberyl", OreItem::new);
-        ITEMS.register("hellas_cinnabar", OreItem::new);
-        ITEMS.register("hellas_citrine", OreItem::new);
-        ITEMS.register("hellas_diamond", OreItem::new);
-        ITEMS.register("hellas_dolomite", OreItem::new);
-        ITEMS.register("hellas_emerald", OreItem::new);
-        ITEMS.register("hellas_erythrite", OreItem::new);
-        ITEMS.register("hellas_flourite", OreItem::new);
-        ITEMS.register("hellas_fuchsite", OreItem::new);
-        ITEMS.register("hellas_garnet", OreItem::new);
-        ITEMS.register("hellas_green_flourite", OreItem::new);
-        ITEMS.register("hellas_hexagonite", OreItem::new);
-        ITEMS.register("hellas_jade", OreItem::new);
-        ITEMS.register("hellas_jasper", OreItem::new);
-        ITEMS.register("hellas_lapis_lazuli", OreItem::new);
-        ITEMS.register("hellas_lazulite", OreItem::new);
-        ITEMS.register("hellas_lazurite", OreItem::new);
-        ITEMS.register("hellas_malachite", OreItem::new);
-        ITEMS.register("hellas_mithril", OreItem::new);
-        ITEMS.register("hellas_morganite", OreItem::new);
-        ITEMS.register("hellas_moss_agate", OreItem::new);
-        ITEMS.register("hellas_nephrite", OreItem::new);
-        ITEMS.register("hellas_neptunite", OreItem::new);
-        ITEMS.register("hellas_obsidian", OreItem::new);
-        ITEMS.register("hellas_onyx", OreItem::new);
-        ITEMS.register("hellas_opal", OreItem::new);
-        ITEMS.register("hellas_orange_flourite", OreItem::new);
-        ITEMS.register("hellas_peridot", OreItem::new);
-        ITEMS.register("hellas_peridotite", OreItem::new);
-        ITEMS.register("hellas_phosgenite", OreItem::new);
-        ITEMS.register("hellas_phosphophyllite", OreItem::new);
-        ITEMS.register("hellas_phosphosiderite", OreItem::new);
-        ITEMS.register("hellas_pink_ruby", OreItem::new);
-        ITEMS.register("hellas_pink_topaz", OreItem::new);
-        ITEMS.register("hellas_pupurite", OreItem::new);
-        ITEMS.register("hellas_purple_flourite", OreItem::new);
-        ITEMS.register("hellas_pyrargyrite", OreItem::new);
-        ITEMS.register("hellas_pyrite", OreItem::new);
-        ITEMS.register("hellas_pyroxmagnite", OreItem::new);
-        ITEMS.register("hellas_quartz", OreItem::new);
-        ITEMS.register("hellas_red_flourite", OreItem::new);
-        ITEMS.register("hellas_rose_quartz", OreItem::new);
-        ITEMS.register("hellas_ruby", OreItem::new);
-        ITEMS.register("hellas_sapphire", OreItem::new);
-        ITEMS.register("hellas_sapphirine", OreItem::new);
-        ITEMS.register("hellas_smoky_quartz", OreItem::new);
-        ITEMS.register("hellas_soapstone", OreItem::new);
-        ITEMS.register("hellas_sulfur", OreItem::new);
-        ITEMS.register("hellas_tanzanite", OreItem::new);
-        ITEMS.register("hellas_titanite", OreItem::new);
-        ITEMS.register("hellas_topaz", OreItem::new);
-        ITEMS.register("hellas_turquoise", OreItem::new);
-        ITEMS.register("hellas_yellow_flourite", OreItem::new);
+            ITEMS.register("hellas_adamantite", OreItem::new);
+            ITEMS.register("hellas_amazonite", OreItem::new);
+            ITEMS.register("hellas_amber", OreItem::new);
+            ITEMS.register("hellas_amethyst", OreItem::new);
+            ITEMS.register("hellas_ametrine", OreItem::new);
+            ITEMS.register("hellas_apatite", OreItem::new);
+            ITEMS.register("hellas_aquamarine", OreItem::new);
+            ITEMS.register("hellas_aventurine", OreItem::new);
+            ITEMS.register("hellas_azurite", OreItem::new);
+            ITEMS.register("hellas_blue_flourite", OreItem::new);
+            ITEMS.register("hellas_blue_quartz", OreItem::new);
+            ITEMS.register("hellas_blue_topaz", OreItem::new);
+            ITEMS.register("hellas_carnelian", OreItem::new);
+            ITEMS.register("hellas_chromite", OreItem::new);
+            ITEMS.register("hellas_chrysoberyl", OreItem::new);
+            ITEMS.register("hellas_cinnabar", OreItem::new);
+            ITEMS.register("hellas_citrine", OreItem::new);
+            ITEMS.register("hellas_diamond", OreItem::new);
+            ITEMS.register("hellas_dolomite", OreItem::new);
+            ITEMS.register("hellas_emerald", OreItem::new);
+            ITEMS.register("hellas_erythrite", OreItem::new);
+            ITEMS.register("hellas_flourite", OreItem::new);
+            ITEMS.register("hellas_fuchsite", OreItem::new);
+            ITEMS.register("hellas_garnet", OreItem::new);
+            ITEMS.register("hellas_green_flourite", OreItem::new);
+            ITEMS.register("hellas_hexagonite", OreItem::new);
+            ITEMS.register("hellas_jade", OreItem::new);
+            ITEMS.register("hellas_jasper", OreItem::new);
+            ITEMS.register("hellas_lapis_lazuli", OreItem::new);
+            ITEMS.register("hellas_lazulite", OreItem::new);
+            ITEMS.register("hellas_lazurite", OreItem::new);
+            ITEMS.register("hellas_malachite", OreItem::new);
+            ITEMS.register("hellas_mithril", OreItem::new);
+            ITEMS.register("hellas_morganite", OreItem::new);
+            ITEMS.register("hellas_moss_agate", OreItem::new);
+            ITEMS.register("hellas_nephrite", OreItem::new);
+            ITEMS.register("hellas_neptunite", OreItem::new);
+            ITEMS.register("hellas_obsidian", OreItem::new);
+            ITEMS.register("hellas_onyx", OreItem::new);
+            ITEMS.register("hellas_opal", OreItem::new);
+            ITEMS.register("hellas_orange_flourite", OreItem::new);
+            ITEMS.register("hellas_peridot", OreItem::new);
+            ITEMS.register("hellas_peridotite", OreItem::new);
+            ITEMS.register("hellas_phosgenite", OreItem::new);
+            ITEMS.register("hellas_phosphophyllite", OreItem::new);
+            ITEMS.register("hellas_phosphosiderite", OreItem::new);
+            ITEMS.register("hellas_pink_ruby", OreItem::new);
+            ITEMS.register("hellas_pink_topaz", OreItem::new);
+            ITEMS.register("hellas_pupurite", OreItem::new);
+            ITEMS.register("hellas_purple_flourite", OreItem::new);
+            ITEMS.register("hellas_pyrargyrite", OreItem::new);
+            ITEMS.register("hellas_pyrite", OreItem::new);
+            ITEMS.register("hellas_pyroxmagnite", OreItem::new);
+            ITEMS.register("hellas_quartz", OreItem::new);
+            ITEMS.register("hellas_red_flourite", OreItem::new);
+            ITEMS.register("hellas_rose_quartz", OreItem::new);
+            ITEMS.register("hellas_ruby", OreItem::new);
+            ITEMS.register("hellas_sapphire", OreItem::new);
+            ITEMS.register("hellas_sapphirine", OreItem::new);
+            ITEMS.register("hellas_smoky_quartz", OreItem::new);
+            ITEMS.register("hellas_soapstone", OreItem::new);
+            ITEMS.register("hellas_sulfur", OreItem::new);
+            ITEMS.register("hellas_tanzanite", OreItem::new);
+            ITEMS.register("hellas_titanite", OreItem::new);
+            ITEMS.register("hellas_topaz", OreItem::new);
+            ITEMS.register("hellas_turquoise", OreItem::new);
+            ITEMS.register("hellas_yellow_flourite", OreItem::new);
 
-        ItemRegistration.ITEMS.register("hellas_coupon", QuestItem::new);
-        ItemRegistration.ITEMS.register("deck-of-many-mons", QuestItem::new);
+            ItemRegistration.ITEMS.register("hellas_coupon", QuestItem::new);
+            ItemRegistration.ITEMS.register("deck-of-many-mons", QuestItem::new);
 
-        ITEMS.register(FMLJavaModLoadingContext.get().getModEventBus());
+            ITEMS.register(FMLJavaModLoadingContext.get().getModEventBus());
+        });
     }
 
     private void setup(FMLCommonSetupEvent event) {
-        LOGGER.info("Loaded HellasForms (hopefully XD)");
+        DebuggingHooks.runWithTracing("setup(FMLCommonSetupEvent)", LOGGER, () ->
+                LOGGER.info("Loaded HellasForms (hopefully XD)"));
     }
 
     @SubscribeEvent
     public void onServerStarting(FMLServerStartingEvent event) {
-        infoConfig.load(event.getServer().getServerDirectory());
-        Pixelmon.EVENT_BUS.register(new ReturnItemsListener());
-        MinecraftForge.EVENT_BUS.register(new GrowthSpawningListener());
+        DebuggingHooks.runWithTracing("onServerStarting(FMLServerStartingEvent)", LOGGER, () -> {
+            infoConfig.load(event.getServer().getServerDirectory());
+            Pixelmon.EVENT_BUS.register(new ReturnItemsListener());
+            MinecraftForge.EVENT_BUS.register(new GrowthSpawningListener());
+        });
     }
 
     @SubscribeEvent
@@ -251,14 +258,24 @@ public class HellasForms {
     }
 
     @SubscribeEvent
-    public void commonSetup(FMLCommonSetupEvent event) { }
+    public void commonSetup(FMLCommonSetupEvent event) {
+        DebuggingHooks.runWithTracing("commonSetup(FMLCommonSetupEvent)", LOGGER, () -> {
+            // Intentionally blank hook for future use
+        });
+    }
 
     @SubscribeEvent
-    public void clientSetup(FMLClientSetupEvent event) { }
+    public void clientSetup(FMLClientSetupEvent event) {
+        DebuggingHooks.runWithTracing("clientSetup(FMLClientSetupEvent)", LOGGER, () -> {
+            // Intentionally blank hook for future use
+        });
+    }
 
     private void onRegisterCommands(RegisterCommandsEvent event) {
-        FormsVersionCommand.register(event.getDispatcher(), infoConfig);
-        FormsDependenciesCommand.register(event.getDispatcher(), infoConfig);
-        FormsFeaturesCommand.register(event.getDispatcher(), infoConfig);
+        DebuggingHooks.runWithTracing("onRegisterCommands", LOGGER, () -> {
+            FormsVersionCommand.register(event.getDispatcher(), infoConfig);
+            FormsDependenciesCommand.register(event.getDispatcher(), infoConfig);
+            FormsFeaturesCommand.register(event.getDispatcher(), infoConfig);
+        });
     }
 }

--- a/src/main/java/com/xsasakihaise/hellasforms/diagnostics/DebuggingHooks.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/diagnostics/DebuggingHooks.java
@@ -1,0 +1,115 @@
+package com.xsasakihaise.hellasforms.diagnostics;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.event.lifecycle.FMLLoadCompleteEvent;
+import net.minecraftforge.fml.event.server.FMLServerStartedEvent;
+import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
+import net.minecraftforge.fml.event.server.FMLServerStoppedEvent;
+import net.minecraftforge.fml.event.server.FMLServerStoppingEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import org.apache.logging.log4j.Logger;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Central location for all debugging helpers. This class tries to give as much
+ * context as possible when the mod loads so that a crash immediately points to
+ * the lifecycle phase that triggered it.
+ */
+public final class DebuggingHooks {
+
+    private static final AtomicBoolean INITIALIZED = new AtomicBoolean(false);
+    private static final String DEBUG_PREFIX = "[HellasForms Debug]";
+
+    private DebuggingHooks() {
+        // Utility class
+    }
+
+    public static void initialize(Logger logger) {
+        Objects.requireNonNull(logger, "logger");
+        if (!INITIALIZED.compareAndSet(false, true)) {
+            return;
+        }
+
+        logRuntimeDetails(logger);
+        installExceptionHandler(logger);
+        installLifecycleLogging(logger);
+    }
+
+    public static void runWithTracing(String stageName, Logger logger, ThrowingRunnable runnable) {
+        Objects.requireNonNull(stageName, "stageName");
+        Objects.requireNonNull(logger, "logger");
+        Objects.requireNonNull(runnable, "runnable");
+
+        logger.info("{} >>> Entering {}", DEBUG_PREFIX, stageName);
+        Instant start = Instant.now();
+        try {
+            runnable.run();
+            Duration elapsed = Duration.between(start, Instant.now());
+            logger.info("{} <<< Finished {} in {} ms", DEBUG_PREFIX, stageName, elapsed.toMillis());
+        } catch (Throwable throwable) {
+            logStageFailure(stageName, logger, throwable);
+            throw rethrow(throwable);
+        }
+    }
+
+    private static void logStageFailure(String stageName, Logger logger, Throwable throwable) {
+        logger.fatal("{} !!! Failure inside {}: {}", DEBUG_PREFIX, stageName, throwable.toString(), throwable);
+    }
+
+    private static RuntimeException rethrow(Throwable throwable) {
+        if (throwable instanceof RuntimeException) {
+            return (RuntimeException) throwable;
+        }
+        return new RuntimeException(throwable);
+    }
+
+    private static void installExceptionHandler(Logger logger) {
+        Thread.UncaughtExceptionHandler previous = Thread.getDefaultUncaughtExceptionHandler();
+        Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
+            logger.fatal("{} Uncaught exception on thread '{}': {}", DEBUG_PREFIX, thread.getName(), throwable.toString(), throwable);
+            if (previous != null) {
+                previous.uncaughtException(thread, throwable);
+            }
+        });
+    }
+
+    private static void installLifecycleLogging(Logger logger) {
+        IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+        modEventBus.addListener((FMLCommonSetupEvent event) -> logLifecycleMarker("FMLCommonSetupEvent", logger));
+        modEventBus.addListener((FMLClientSetupEvent event) -> logLifecycleMarker("FMLClientSetupEvent", logger));
+        modEventBus.addListener((FMLLoadCompleteEvent event) -> logLifecycleMarker("FMLLoadCompleteEvent", logger));
+
+        MinecraftForge.EVENT_BUS.addListener((FMLServerStartingEvent event) -> logLifecycleMarker("FMLServerStartingEvent", logger));
+        MinecraftForge.EVENT_BUS.addListener((FMLServerStartedEvent event) -> logLifecycleMarker("FMLServerStartedEvent", logger));
+        MinecraftForge.EVENT_BUS.addListener((FMLServerStoppingEvent event) -> logLifecycleMarker("FMLServerStoppingEvent", logger));
+        MinecraftForge.EVENT_BUS.addListener((FMLServerStoppedEvent event) -> logLifecycleMarker("FMLServerStoppedEvent", logger));
+    }
+
+    private static void logLifecycleMarker(String stage, Logger logger) {
+        logger.info("{} Event fired: {}", DEBUG_PREFIX, stage);
+    }
+
+    private static void logRuntimeDetails(Logger logger) {
+        RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
+        List<String> inputArguments = runtimeMXBean.getInputArguments();
+        logger.info("{} Java version: {}", DEBUG_PREFIX, System.getProperty("java.version"));
+        logger.info("{} JVM name: {}", DEBUG_PREFIX, runtimeMXBean.getVmName());
+        logger.info("{} JVM vendor: {}", DEBUG_PREFIX, runtimeMXBean.getVmVendor());
+        logger.info("{} Launch arguments: {}", DEBUG_PREFIX, inputArguments);
+    }
+
+    @FunctionalInterface
+    public interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+}


### PR DESCRIPTION
## Summary
- add a diagnostics helper that installs global exception logging and lifecycle event tracing
- wrap HellasForms lifecycle handlers and registration code with tracing to pinpoint failures during load

## Testing
- ./gradlew build *(fails: unable to download Gradle wrapper due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_690548a496d883318d71f485636c8eac