### PR TITLE
Add structured logging flags across HellasForms subsystems

### DIFF
--- a/src/main/java/com/xsasakihaise/hellasforms/HellasForms.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/HellasForms.java
@@ -19,6 +19,7 @@ import com.xsasakihaise.hellasforms.items.consumables.ExperienceCandyItem;
 import com.xsasakihaise.hellasforms.items.consumables.RustedBottleCapItem;
 import com.xsasakihaise.hellasforms.items.heldItems.EeveeoliteItem;
 import com.xsasakihaise.hellasforms.diagnostics.DebuggingHooks;
+import com.xsasakihaise.hellasforms.diagnostics.LogFlag;
 import com.xsasakihaise.hellasforms.listener.GrowthSpawningListener;
 import com.xsasakihaise.hellasforms.listener.ReturnItemsListener;
 import net.minecraft.item.Item;
@@ -44,12 +45,12 @@ import com.xsasakihaise.hellasforms.util.PixelmonStatTypes;
 @Mod("hellasforms")
 public class HellasForms {
 
-    static {
-        HellasAPIControlForms.verify();
-    }
-
     public static final String MOD_ID = "hellasforms";
     public static final Logger LOGGER = LogManager.getLogger("hellasforms");
+
+    static {
+        DebuggingHooks.runWithTracing(LogFlag.API, "HellasAPIControlForms.verify()", LOGGER, HellasAPIControlForms::verify);
+    }
     private static HellasForms instance;
     public static HellasFormsInfoConfig infoConfig;
     public static final DeferredRegister<Item> ITEMS;
@@ -60,182 +61,196 @@ public class HellasForms {
 
     public HellasForms() {
         DebuggingHooks.initialize(LOGGER);
-        DebuggingHooks.runWithTracing("HellasForms::<init>", LOGGER, () -> {
+        DebuggingHooks.runWithTracing(LogFlag.CORE, "HellasForms::<init>", LOGGER, () -> {
             instance = this;
-            IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
-            modEventBus.addListener(this::setup);
-            MinecraftForge.EVENT_BUS.register(this);
-            infoConfig = new HellasFormsInfoConfig();
-            infoConfig.loadDefaultsFromResource();
-            MinecraftForge.EVENT_BUS.addListener(this::onRegisterCommands);
 
-            EffectTypeAdapter.EFFECTS.put("ColonySwarm", ColonySwarm.class);
-            EffectTypeAdapter.EFFECTS.put("Corrode", Corrode.class);
-            EffectTypeAdapter.EFFECTS.put("GreekFire", GreekFire.class);
-            EffectTypeAdapter.EFFECTS.put("HitchKick", HitchKick.class);
-            EffectTypeAdapter.EFFECTS.put("PlasmaFangs", PlasmaFangs.class);
-            EffectTypeAdapter.EFFECTS.put("RabidClaw", RabidClaw.class);
-            EffectTypeAdapter.EFFECTS.put("PlasmaVeil", PlasmaVeil.class);
+            DebuggingHooks.runWithTracing(LogFlag.CORE, "registerLifecycleListeners", LOGGER, () -> {
+                IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+                modEventBus.addListener(this::setup);
+                MinecraftForge.EVENT_BUS.register(this);
+                MinecraftForge.EVENT_BUS.addListener(this::onRegisterCommands);
+            });
 
-            EffectTypeAdapter.EFFECTS.put("RadiantEnergy", RadiantEnergy.class);
-            EffectTypeAdapter.EFFECTS.put("BleedingJaw", BleedingJaw.class);
-            EffectTypeAdapter.EFFECTS.put("Shatterstorm", Shatterstorm.class);
-            EffectTypeAdapter.EFFECTS.put("SnowstormFury", SnowstormFury.class);
-            EffectTypeAdapter.EFFECTS.put("Afterburner", Afterburner.class);
-            EffectTypeAdapter.EFFECTS.put("VenomAmbush", VenomAmbush.class);
-            EffectTypeAdapter.EFFECTS.put("DC", DC.class);
-            EffectTypeAdapter.EFFECTS.put("PhotonDarts", PhotonDarts.class);
-            EffectTypeAdapter.EFFECTS.put("SurgeBurrow", SurgeBurrow.class);
+            DebuggingHooks.runWithTracing(LogFlag.CONFIG, "initializeInfoConfig", LOGGER, () -> {
+                infoConfig = new HellasFormsInfoConfig();
+                infoConfig.loadDefaultsFromResource();
+            });
 
-            EffectTypeAdapter.EFFECTS.put("TiroFinale", TiroFinale.class);
-            EffectTypeAdapter.EFFECTS.put("AuroraInfernalis", AuroraInfernalis.class);
-            EffectTypeAdapter.EFFECTS.put("StingingNettle", StingingNettle.class);
-            EffectTypeAdapter.EFFECTS.put("PetalBurst", PetalBurst.class);
-            EffectTypeAdapter.EFFECTS.put("Purification", Purification.class);
-            EffectTypeAdapter.EFFECTS.put("Thermodynamics", Thermodynamics.class);
-            EffectTypeAdapter.EFFECTS.put("IcyImmolation", IcyImmolation.class);
+            DebuggingHooks.runWithTracing(LogFlag.BATTLES, "registerBattleEffectAdapters", LOGGER, () -> {
+                EffectTypeAdapter.EFFECTS.put("ColonySwarm", ColonySwarm.class);
+                EffectTypeAdapter.EFFECTS.put("Corrode", Corrode.class);
+                EffectTypeAdapter.EFFECTS.put("GreekFire", GreekFire.class);
+                EffectTypeAdapter.EFFECTS.put("HitchKick", HitchKick.class);
+                EffectTypeAdapter.EFFECTS.put("PlasmaFangs", PlasmaFangs.class);
+                EffectTypeAdapter.EFFECTS.put("RabidClaw", RabidClaw.class);
+                EffectTypeAdapter.EFFECTS.put("PlasmaVeil", PlasmaVeil.class);
 
-            ItemRegistration.ITEMS.register("eeveeolite", EeveeoliteItem::new);
+                EffectTypeAdapter.EFFECTS.put("RadiantEnergy", RadiantEnergy.class);
+                EffectTypeAdapter.EFFECTS.put("BleedingJaw", BleedingJaw.class);
+                EffectTypeAdapter.EFFECTS.put("Shatterstorm", Shatterstorm.class);
+                EffectTypeAdapter.EFFECTS.put("SnowstormFury", SnowstormFury.class);
+                EffectTypeAdapter.EFFECTS.put("Afterburner", Afterburner.class);
+                EffectTypeAdapter.EFFECTS.put("VenomAmbush", VenomAmbush.class);
+                EffectTypeAdapter.EFFECTS.put("DC", DC.class);
+                EffectTypeAdapter.EFFECTS.put("PhotonDarts", PhotonDarts.class);
+                EffectTypeAdapter.EFFECTS.put("SurgeBurrow", SurgeBurrow.class);
 
-            ItemRegistration.ITEMS.register("diancite-hellas", () -> new MegaStoneItem("diancie form:hellas"));
-            ItemRegistration.ITEMS.register("sceptilite-hellas", () -> new MegaStoneItem("sceptile form:hellas"));
-            ItemRegistration.ITEMS.register("gyaradosite-hellas", () -> new MegaStoneItem("gyarados form:hellas"));
-            ItemRegistration.ITEMS.register("tyranitarite-hellas", () -> new MegaStoneItem("tyranitar form:hellas"));
-            ItemRegistration.ITEMS.register("gardevoirite-hellas", () -> new MegaStoneItem("gardevoir form:hellas"));
-            ItemRegistration.ITEMS.register("garchompite-hellas", () -> new MegaStoneItem("garchomp form:hellas"));
-            ItemRegistration.ITEMS.register("galladeite-hellas", () -> new MegaStoneItem("gallade form:hellas"));
-            ItemRegistration.ITEMS.register("samurottite-hellas", () -> new MegaStoneItem("samurott form:hellas"));
-            ItemRegistration.ITEMS.register("centiskorchite-hellas", () -> new MegaStoneItem("centiskorch form:hellas"));
-            ItemRegistration.ITEMS.register("aegislashite-hellas", () -> new MegaStoneItem("aegislash form:hellas"));
-            ItemRegistration.ITEMS.register("goodrite-hellas", () -> new MegaStoneItem("goodra form:hellas"));
+                EffectTypeAdapter.EFFECTS.put("TiroFinale", TiroFinale.class);
+                EffectTypeAdapter.EFFECTS.put("AuroraInfernalis", AuroraInfernalis.class);
+                EffectTypeAdapter.EFFECTS.put("StingingNettle", StingingNettle.class);
+                EffectTypeAdapter.EFFECTS.put("PetalBurst", PetalBurst.class);
+                EffectTypeAdapter.EFFECTS.put("Purification", Purification.class);
+                EffectTypeAdapter.EFFECTS.put("Thermodynamics", Thermodynamics.class);
+                EffectTypeAdapter.EFFECTS.put("IcyImmolation", IcyImmolation.class);
+            });
 
-            ItemRegistration.ITEMS.register("bug_badge_hellas", BadgeItem::new);
-            ItemRegistration.ITEMS.register("dark_badge_hellas", BadgeItem::new);
-            ItemRegistration.ITEMS.register("dragon_badge_hellas", BadgeItem::new);
-            ItemRegistration.ITEMS.register("electric_badge_hellas", BadgeItem::new);
-            ItemRegistration.ITEMS.register("fairy_badge_hellas", BadgeItem::new);
-            ItemRegistration.ITEMS.register("fighting_badge_hellas", BadgeItem::new);
-            ItemRegistration.ITEMS.register("fire_badge_hellas", BadgeItem::new);
-            ItemRegistration.ITEMS.register("flying_badge_hellas", BadgeItem::new);
-            ItemRegistration.ITEMS.register("ghost_badge_hellas", BadgeItem::new);
-            ItemRegistration.ITEMS.register("grass_badge_hellas", BadgeItem::new);
-            ItemRegistration.ITEMS.register("ground_badge_hellas", BadgeItem::new);
-            ItemRegistration.ITEMS.register("ice_badge_hellas", BadgeItem::new);
-            ItemRegistration.ITEMS.register("normal_badge_hellas", BadgeItem::new);
-            ItemRegistration.ITEMS.register("poison_badge_hellas", BadgeItem::new);
-            ItemRegistration.ITEMS.register("psychic_badge_hellas", BadgeItem::new);
-            ItemRegistration.ITEMS.register("rock_badge_hellas", BadgeItem::new);
-            ItemRegistration.ITEMS.register("steel_badge_hellas", BadgeItem::new);
-            ItemRegistration.ITEMS.register("water_badge_hellas", BadgeItem::new);
+            DebuggingHooks.runWithTracing(LogFlag.ITEMS, "registerPixelmonItems", LOGGER, () -> {
+                ItemRegistration.ITEMS.register("eeveeolite", EeveeoliteItem::new);
 
-            ItemRegistration.ITEMS.register("rusted_bottle_cap", RustedBottleCapItem::new);
-            ItemRegistration.ITEMS.register("exp_candy_xxl", () -> new ExperienceCandyItem(60000, "item.pixelmon.exp_candy_xxl.success"));
-            ItemRegistration.ITEMS.register("exp_candy_xxxl", () -> new ExperienceCandyItem(120000, "item.pixelmon.exp_candy_xxxl.success"));
-            ItemRegistration.ITEMS.register("hp_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.hp(), "item.pixelmon.hp_252_ev_capsule.success"));
-            ItemRegistration.ITEMS.register("attack_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.attack(), "item.pixelmon.attack_252_ev_capsule.success"));
-            ItemRegistration.ITEMS.register("defense_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.defence(), "item.pixelmon.defense_252_ev_capsule.success"));
-            ItemRegistration.ITEMS.register("spatk_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.specialAttack(), "item.pixelmon.spatk_252_ev_capsule.success"));
-            ItemRegistration.ITEMS.register("spdef_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.specialDefence(), "item.pixelmon.spdef_252_ev_capsule.success"));
-            ItemRegistration.ITEMS.register("speed_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.speed(), "item.pixelmon.speed_252_ev_capsule.success"));
-            ItemRegistration.ITEMS.register("ability_patch_remover", AbilityPatchRemoverItem::new);
+                ItemRegistration.ITEMS.register("diancite-hellas", () -> new MegaStoneItem("diancie form:hellas"));
+                ItemRegistration.ITEMS.register("sceptilite-hellas", () -> new MegaStoneItem("sceptile form:hellas"));
+                ItemRegistration.ITEMS.register("gyaradosite-hellas", () -> new MegaStoneItem("gyarados form:hellas"));
+                ItemRegistration.ITEMS.register("tyranitarite-hellas", () -> new MegaStoneItem("tyranitar form:hellas"));
+                ItemRegistration.ITEMS.register("gardevoirite-hellas", () -> new MegaStoneItem("gardevoir form:hellas"));
+                ItemRegistration.ITEMS.register("garchompite-hellas", () -> new MegaStoneItem("garchomp form:hellas"));
+                ItemRegistration.ITEMS.register("galladeite-hellas", () -> new MegaStoneItem("gallade form:hellas"));
+                ItemRegistration.ITEMS.register("samurottite-hellas", () -> new MegaStoneItem("samurott form:hellas"));
+                ItemRegistration.ITEMS.register("centiskorchite-hellas", () -> new MegaStoneItem("centiskorch form:hellas"));
+                ItemRegistration.ITEMS.register("aegislashite-hellas", () -> new MegaStoneItem("aegislash form:hellas"));
+                ItemRegistration.ITEMS.register("goodrite-hellas", () -> new MegaStoneItem("goodra form:hellas"));
 
-            ITEMS.register("wild-egg", PokemonEggItem::new);
-            ITEMS.register("hellasian-egg", PokemonEggItem::new);
-            ITEMS.register("odd-looking-egg", PokemonEggItem::new);
-            ITEMS.register("sparkly-wild-egg", PokemonEggItem::new);
-            ITEMS.register("sparkly-hellasian-egg", PokemonEggItem::new);
-            ITEMS.register("sparkly-odd-looking-egg", PokemonEggItem::new);
+                ItemRegistration.ITEMS.register("bug_badge_hellas", BadgeItem::new);
+                ItemRegistration.ITEMS.register("dark_badge_hellas", BadgeItem::new);
+                ItemRegistration.ITEMS.register("dragon_badge_hellas", BadgeItem::new);
+                ItemRegistration.ITEMS.register("electric_badge_hellas", BadgeItem::new);
+                ItemRegistration.ITEMS.register("fairy_badge_hellas", BadgeItem::new);
+                ItemRegistration.ITEMS.register("fighting_badge_hellas", BadgeItem::new);
+                ItemRegistration.ITEMS.register("fire_badge_hellas", BadgeItem::new);
+                ItemRegistration.ITEMS.register("flying_badge_hellas", BadgeItem::new);
+                ItemRegistration.ITEMS.register("ghost_badge_hellas", BadgeItem::new);
+                ItemRegistration.ITEMS.register("grass_badge_hellas", BadgeItem::new);
+                ItemRegistration.ITEMS.register("ground_badge_hellas", BadgeItem::new);
+                ItemRegistration.ITEMS.register("ice_badge_hellas", BadgeItem::new);
+                ItemRegistration.ITEMS.register("normal_badge_hellas", BadgeItem::new);
+                ItemRegistration.ITEMS.register("poison_badge_hellas", BadgeItem::new);
+                ItemRegistration.ITEMS.register("psychic_badge_hellas", BadgeItem::new);
+                ItemRegistration.ITEMS.register("rock_badge_hellas", BadgeItem::new);
+                ItemRegistration.ITEMS.register("steel_badge_hellas", BadgeItem::new);
+                ItemRegistration.ITEMS.register("water_badge_hellas", BadgeItem::new);
 
-            for (int i = 1; i <= 20; i++) {
-                ITEMS.register("battlepass_item_" + i, BattlePassItem::new);
-            }
+                ItemRegistration.ITEMS.register("rusted_bottle_cap", RustedBottleCapItem::new);
+                ItemRegistration.ITEMS.register("exp_candy_xxl", () -> new ExperienceCandyItem(60000, "item.pixelmon.exp_candy_xxl.success"));
+                ItemRegistration.ITEMS.register("exp_candy_xxxl", () -> new ExperienceCandyItem(120000, "item.pixelmon.exp_candy_xxxl.success"));
+                ItemRegistration.ITEMS.register("hp_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.hp(), "item.pixelmon.hp_252_ev_capsule.success"));
+                ItemRegistration.ITEMS.register("attack_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.attack(), "item.pixelmon.attack_252_ev_capsule.success"));
+                ItemRegistration.ITEMS.register("defense_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.defence(), "item.pixelmon.defense_252_ev_capsule.success"));
+                ItemRegistration.ITEMS.register("spatk_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.specialAttack(), "item.pixelmon.spatk_252_ev_capsule.success"));
+                ItemRegistration.ITEMS.register("spdef_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.specialDefence(), "item.pixelmon.spdef_252_ev_capsule.success"));
+                ItemRegistration.ITEMS.register("speed_252_ev_capsule", () -> new EvMaximizerItem(PixelmonStatTypes.speed(), "item.pixelmon.speed_252_ev_capsule.success"));
+                ItemRegistration.ITEMS.register("ability_patch_remover", AbilityPatchRemoverItem::new);
+                ItemRegistration.ITEMS.register("hellas_coupon", QuestItem::new);
+                ItemRegistration.ITEMS.register("deck-of-many-mons", QuestItem::new);
+            });
 
-            ITEMS.register("hellas_adamantite", OreItem::new);
-            ITEMS.register("hellas_amazonite", OreItem::new);
-            ITEMS.register("hellas_amber", OreItem::new);
-            ITEMS.register("hellas_amethyst", OreItem::new);
-            ITEMS.register("hellas_ametrine", OreItem::new);
-            ITEMS.register("hellas_apatite", OreItem::new);
-            ITEMS.register("hellas_aquamarine", OreItem::new);
-            ITEMS.register("hellas_aventurine", OreItem::new);
-            ITEMS.register("hellas_azurite", OreItem::new);
-            ITEMS.register("hellas_blue_flourite", OreItem::new);
-            ITEMS.register("hellas_blue_quartz", OreItem::new);
-            ITEMS.register("hellas_blue_topaz", OreItem::new);
-            ITEMS.register("hellas_carnelian", OreItem::new);
-            ITEMS.register("hellas_chromite", OreItem::new);
-            ITEMS.register("hellas_chrysoberyl", OreItem::new);
-            ITEMS.register("hellas_cinnabar", OreItem::new);
-            ITEMS.register("hellas_citrine", OreItem::new);
-            ITEMS.register("hellas_diamond", OreItem::new);
-            ITEMS.register("hellas_dolomite", OreItem::new);
-            ITEMS.register("hellas_emerald", OreItem::new);
-            ITEMS.register("hellas_erythrite", OreItem::new);
-            ITEMS.register("hellas_flourite", OreItem::new);
-            ITEMS.register("hellas_fuchsite", OreItem::new);
-            ITEMS.register("hellas_garnet", OreItem::new);
-            ITEMS.register("hellas_green_flourite", OreItem::new);
-            ITEMS.register("hellas_hexagonite", OreItem::new);
-            ITEMS.register("hellas_jade", OreItem::new);
-            ITEMS.register("hellas_jasper", OreItem::new);
-            ITEMS.register("hellas_lapis_lazuli", OreItem::new);
-            ITEMS.register("hellas_lazulite", OreItem::new);
-            ITEMS.register("hellas_lazurite", OreItem::new);
-            ITEMS.register("hellas_malachite", OreItem::new);
-            ITEMS.register("hellas_mithril", OreItem::new);
-            ITEMS.register("hellas_morganite", OreItem::new);
-            ITEMS.register("hellas_moss_agate", OreItem::new);
-            ITEMS.register("hellas_nephrite", OreItem::new);
-            ITEMS.register("hellas_neptunite", OreItem::new);
-            ITEMS.register("hellas_obsidian", OreItem::new);
-            ITEMS.register("hellas_onyx", OreItem::new);
-            ITEMS.register("hellas_opal", OreItem::new);
-            ITEMS.register("hellas_orange_flourite", OreItem::new);
-            ITEMS.register("hellas_peridot", OreItem::new);
-            ITEMS.register("hellas_peridotite", OreItem::new);
-            ITEMS.register("hellas_phosgenite", OreItem::new);
-            ITEMS.register("hellas_phosphophyllite", OreItem::new);
-            ITEMS.register("hellas_phosphosiderite", OreItem::new);
-            ITEMS.register("hellas_pink_ruby", OreItem::new);
-            ITEMS.register("hellas_pink_topaz", OreItem::new);
-            ITEMS.register("hellas_pupurite", OreItem::new);
-            ITEMS.register("hellas_purple_flourite", OreItem::new);
-            ITEMS.register("hellas_pyrargyrite", OreItem::new);
-            ITEMS.register("hellas_pyrite", OreItem::new);
-            ITEMS.register("hellas_pyroxmagnite", OreItem::new);
-            ITEMS.register("hellas_quartz", OreItem::new);
-            ITEMS.register("hellas_red_flourite", OreItem::new);
-            ITEMS.register("hellas_rose_quartz", OreItem::new);
-            ITEMS.register("hellas_ruby", OreItem::new);
-            ITEMS.register("hellas_sapphire", OreItem::new);
-            ITEMS.register("hellas_sapphirine", OreItem::new);
-            ITEMS.register("hellas_smoky_quartz", OreItem::new);
-            ITEMS.register("hellas_soapstone", OreItem::new);
-            ITEMS.register("hellas_sulfur", OreItem::new);
-            ITEMS.register("hellas_tanzanite", OreItem::new);
-            ITEMS.register("hellas_titanite", OreItem::new);
-            ITEMS.register("hellas_topaz", OreItem::new);
-            ITEMS.register("hellas_turquoise", OreItem::new);
-            ITEMS.register("hellas_yellow_flourite", OreItem::new);
+            DebuggingHooks.runWithTracing(LogFlag.ITEMS, "registerHellasItems", LOGGER, () -> {
+                ITEMS.register("wild-egg", PokemonEggItem::new);
+                ITEMS.register("hellasian-egg", PokemonEggItem::new);
+                ITEMS.register("odd-looking-egg", PokemonEggItem::new);
+                ITEMS.register("sparkly-wild-egg", PokemonEggItem::new);
+                ITEMS.register("sparkly-hellasian-egg", PokemonEggItem::new);
+                ITEMS.register("sparkly-odd-looking-egg", PokemonEggItem::new);
 
-            ItemRegistration.ITEMS.register("hellas_coupon", QuestItem::new);
-            ItemRegistration.ITEMS.register("deck-of-many-mons", QuestItem::new);
+                for (int i = 1; i <= 20; i++) {
+                    ITEMS.register("battlepass_item_" + i, BattlePassItem::new);
+                }
 
-            ITEMS.register(FMLJavaModLoadingContext.get().getModEventBus());
+                ITEMS.register("hellas_adamantite", OreItem::new);
+                ITEMS.register("hellas_amazonite", OreItem::new);
+                ITEMS.register("hellas_amber", OreItem::new);
+                ITEMS.register("hellas_amethyst", OreItem::new);
+                ITEMS.register("hellas_ametrine", OreItem::new);
+                ITEMS.register("hellas_apatite", OreItem::new);
+                ITEMS.register("hellas_aquamarine", OreItem::new);
+                ITEMS.register("hellas_aventurine", OreItem::new);
+                ITEMS.register("hellas_azurite", OreItem::new);
+                ITEMS.register("hellas_blue_flourite", OreItem::new);
+                ITEMS.register("hellas_blue_quartz", OreItem::new);
+                ITEMS.register("hellas_blue_topaz", OreItem::new);
+                ITEMS.register("hellas_carnelian", OreItem::new);
+                ITEMS.register("hellas_chromite", OreItem::new);
+                ITEMS.register("hellas_chrysoberyl", OreItem::new);
+                ITEMS.register("hellas_cinnabar", OreItem::new);
+                ITEMS.register("hellas_citrine", OreItem::new);
+                ITEMS.register("hellas_diamond", OreItem::new);
+                ITEMS.register("hellas_dolomite", OreItem::new);
+                ITEMS.register("hellas_emerald", OreItem::new);
+                ITEMS.register("hellas_erythrite", OreItem::new);
+                ITEMS.register("hellas_flourite", OreItem::new);
+                ITEMS.register("hellas_fuchsite", OreItem::new);
+                ITEMS.register("hellas_garnet", OreItem::new);
+                ITEMS.register("hellas_green_flourite", OreItem::new);
+                ITEMS.register("hellas_hexagonite", OreItem::new);
+                ITEMS.register("hellas_jade", OreItem::new);
+                ITEMS.register("hellas_jasper", OreItem::new);
+                ITEMS.register("hellas_lapis_lazuli", OreItem::new);
+                ITEMS.register("hellas_lazulite", OreItem::new);
+                ITEMS.register("hellas_lazurite", OreItem::new);
+                ITEMS.register("hellas_malachite", OreItem::new);
+                ITEMS.register("hellas_mithril", OreItem::new);
+                ITEMS.register("hellas_morganite", OreItem::new);
+                ITEMS.register("hellas_moss_agate", OreItem::new);
+                ITEMS.register("hellas_nephrite", OreItem::new);
+                ITEMS.register("hellas_neptunite", OreItem::new);
+                ITEMS.register("hellas_obsidian", OreItem::new);
+                ITEMS.register("hellas_onyx", OreItem::new);
+                ITEMS.register("hellas_opal", OreItem::new);
+                ITEMS.register("hellas_orange_flourite", OreItem::new);
+                ITEMS.register("hellas_peridot", OreItem::new);
+                ITEMS.register("hellas_peridotite", OreItem::new);
+                ITEMS.register("hellas_phosgenite", OreItem::new);
+                ITEMS.register("hellas_phosphophyllite", OreItem::new);
+                ITEMS.register("hellas_phosphosiderite", OreItem::new);
+                ITEMS.register("hellas_pink_ruby", OreItem::new);
+                ITEMS.register("hellas_pink_topaz", OreItem::new);
+                ITEMS.register("hellas_pupurite", OreItem::new);
+                ITEMS.register("hellas_purple_flourite", OreItem::new);
+                ITEMS.register("hellas_pyrargyrite", OreItem::new);
+                ITEMS.register("hellas_pyrite", OreItem::new);
+                ITEMS.register("hellas_pyroxmagnite", OreItem::new);
+                ITEMS.register("hellas_quartz", OreItem::new);
+                ITEMS.register("hellas_red_flourite", OreItem::new);
+                ITEMS.register("hellas_rose_quartz", OreItem::new);
+                ITEMS.register("hellas_ruby", OreItem::new);
+                ITEMS.register("hellas_sapphire", OreItem::new);
+                ITEMS.register("hellas_sapphirine", OreItem::new);
+                ITEMS.register("hellas_smoky_quartz", OreItem::new);
+                ITEMS.register("hellas_soapstone", OreItem::new);
+                ITEMS.register("hellas_sulfur", OreItem::new);
+                ITEMS.register("hellas_tanzanite", OreItem::new);
+                ITEMS.register("hellas_titanite", OreItem::new);
+                ITEMS.register("hellas_topaz", OreItem::new);
+                ITEMS.register("hellas_turquoise", OreItem::new);
+                ITEMS.register("hellas_yellow_flourite", OreItem::new);
+
+                ITEMS.register(FMLJavaModLoadingContext.get().getModEventBus());
+            });
         });
     }
 
     private void setup(FMLCommonSetupEvent event) {
-        DebuggingHooks.runWithTracing("setup(FMLCommonSetupEvent)", LOGGER, () ->
-                LOGGER.info("Loaded HellasForms (hopefully XD)"));
+        DebuggingHooks.runWithTracing(LogFlag.CORE, "setup(FMLCommonSetupEvent)", LOGGER, () ->
+                LOGGER.info("{} Loaded HellasForms (hopefully XD)", LogFlag.CORE.format()));
     }
 
     @SubscribeEvent
     public void onServerStarting(FMLServerStartingEvent event) {
-        DebuggingHooks.runWithTracing("onServerStarting(FMLServerStartingEvent)", LOGGER, () -> {
-            infoConfig.load(event.getServer().getServerDirectory());
-            Pixelmon.EVENT_BUS.register(new ReturnItemsListener());
-            MinecraftForge.EVENT_BUS.register(new GrowthSpawningListener());
+        DebuggingHooks.runWithTracing(LogFlag.CORE, "onServerStarting(FMLServerStartingEvent)", LOGGER, () -> {
+            DebuggingHooks.runWithTracing(LogFlag.CONFIG, "HellasFormsInfoConfig.load", LOGGER, () ->
+                    infoConfig.load(event.getServer().getServerDirectory()));
+            DebuggingHooks.runWithTracing(LogFlag.LISTENERS, "registerReturnItemsListener", LOGGER, () ->
+                    Pixelmon.EVENT_BUS.register(new ReturnItemsListener()));
+            DebuggingHooks.runWithTracing(LogFlag.LISTENERS, "registerGrowthSpawningListener", LOGGER, () ->
+                    MinecraftForge.EVENT_BUS.register(new GrowthSpawningListener()));
         });
     }
 
@@ -259,23 +274,26 @@ public class HellasForms {
 
     @SubscribeEvent
     public void commonSetup(FMLCommonSetupEvent event) {
-        DebuggingHooks.runWithTracing("commonSetup(FMLCommonSetupEvent)", LOGGER, () -> {
+        DebuggingHooks.runWithTracing(LogFlag.CORE, "commonSetup(FMLCommonSetupEvent)", LOGGER, () -> {
             // Intentionally blank hook for future use
         });
     }
 
     @SubscribeEvent
     public void clientSetup(FMLClientSetupEvent event) {
-        DebuggingHooks.runWithTracing("clientSetup(FMLClientSetupEvent)", LOGGER, () -> {
+        DebuggingHooks.runWithTracing(LogFlag.CORE, "clientSetup(FMLClientSetupEvent)", LOGGER, () -> {
             // Intentionally blank hook for future use
         });
     }
 
     private void onRegisterCommands(RegisterCommandsEvent event) {
-        DebuggingHooks.runWithTracing("onRegisterCommands", LOGGER, () -> {
-            FormsVersionCommand.register(event.getDispatcher(), infoConfig);
-            FormsDependenciesCommand.register(event.getDispatcher(), infoConfig);
-            FormsFeaturesCommand.register(event.getDispatcher(), infoConfig);
+        DebuggingHooks.runWithTracing(LogFlag.CORE, "onRegisterCommands", LOGGER, () -> {
+            DebuggingHooks.runWithTracing(LogFlag.COMMANDS, "FormsVersionCommand.register", LOGGER, () ->
+                    FormsVersionCommand.register(event.getDispatcher(), infoConfig));
+            DebuggingHooks.runWithTracing(LogFlag.COMMANDS, "FormsDependenciesCommand.register", LOGGER, () ->
+                    FormsDependenciesCommand.register(event.getDispatcher(), infoConfig));
+            DebuggingHooks.runWithTracing(LogFlag.COMMANDS, "FormsFeaturesCommand.register", LOGGER, () ->
+                    FormsFeaturesCommand.register(event.getDispatcher(), infoConfig));
         });
     }
 }

--- a/src/main/java/com/xsasakihaise/hellasforms/diagnostics/DebuggingHooks.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/diagnostics/DebuggingHooks.java
@@ -40,30 +40,35 @@ public final class DebuggingHooks {
             return;
         }
 
-        logRuntimeDetails(logger);
-        installExceptionHandler(logger);
+        logRuntimeDetails(LogFlag.DIAGNOSTICS, logger);
+        installExceptionHandler(LogFlag.DIAGNOSTICS, logger);
         installLifecycleLogging(logger);
     }
 
     public static void runWithTracing(String stageName, Logger logger, ThrowingRunnable runnable) {
+        runWithTracing(LogFlag.CORE, stageName, logger, runnable);
+    }
+
+    public static void runWithTracing(LogFlag flag, String stageName, Logger logger, ThrowingRunnable runnable) {
         Objects.requireNonNull(stageName, "stageName");
         Objects.requireNonNull(logger, "logger");
         Objects.requireNonNull(runnable, "runnable");
 
-        logger.info("{} >>> Entering {}", DEBUG_PREFIX, stageName);
+        String prefix = formatPrefix(flag);
+        logger.info("{} >>> Entering {}", prefix, stageName);
         Instant start = Instant.now();
         try {
             runnable.run();
             Duration elapsed = Duration.between(start, Instant.now());
-            logger.info("{} <<< Finished {} in {} ms", DEBUG_PREFIX, stageName, elapsed.toMillis());
+            logger.info("{} <<< Finished {} in {} ms", prefix, stageName, elapsed.toMillis());
         } catch (Throwable throwable) {
-            logStageFailure(stageName, logger, throwable);
+            logStageFailure(flag, stageName, logger, throwable);
             throw rethrow(throwable);
         }
     }
 
-    private static void logStageFailure(String stageName, Logger logger, Throwable throwable) {
-        logger.fatal("{} !!! Failure inside {}: {}", DEBUG_PREFIX, stageName, throwable.toString(), throwable);
+    private static void logStageFailure(LogFlag flag, String stageName, Logger logger, Throwable throwable) {
+        logger.fatal("{} !!! Failure inside {}: {}", formatPrefix(flag), stageName, throwable.toString(), throwable);
     }
 
     private static RuntimeException rethrow(Throwable throwable) {
@@ -73,10 +78,10 @@ public final class DebuggingHooks {
         return new RuntimeException(throwable);
     }
 
-    private static void installExceptionHandler(Logger logger) {
+    private static void installExceptionHandler(LogFlag flag, Logger logger) {
         Thread.UncaughtExceptionHandler previous = Thread.getDefaultUncaughtExceptionHandler();
         Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
-            logger.fatal("{} Uncaught exception on thread '{}': {}", DEBUG_PREFIX, thread.getName(), throwable.toString(), throwable);
+            logger.fatal("{} Uncaught exception on thread '{}': {}", formatPrefix(flag), thread.getName(), throwable.toString(), throwable);
             if (previous != null) {
                 previous.uncaughtException(thread, throwable);
             }
@@ -85,27 +90,32 @@ public final class DebuggingHooks {
 
     private static void installLifecycleLogging(Logger logger) {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
-        modEventBus.addListener((FMLCommonSetupEvent event) -> logLifecycleMarker("FMLCommonSetupEvent", logger));
-        modEventBus.addListener((FMLClientSetupEvent event) -> logLifecycleMarker("FMLClientSetupEvent", logger));
-        modEventBus.addListener((FMLLoadCompleteEvent event) -> logLifecycleMarker("FMLLoadCompleteEvent", logger));
+        modEventBus.addListener((FMLCommonSetupEvent event) -> logLifecycleMarker(LogFlag.DIAGNOSTICS, "FMLCommonSetupEvent", logger));
+        modEventBus.addListener((FMLClientSetupEvent event) -> logLifecycleMarker(LogFlag.DIAGNOSTICS, "FMLClientSetupEvent", logger));
+        modEventBus.addListener((FMLLoadCompleteEvent event) -> logLifecycleMarker(LogFlag.DIAGNOSTICS, "FMLLoadCompleteEvent", logger));
 
-        MinecraftForge.EVENT_BUS.addListener((FMLServerStartingEvent event) -> logLifecycleMarker("FMLServerStartingEvent", logger));
-        MinecraftForge.EVENT_BUS.addListener((FMLServerStartedEvent event) -> logLifecycleMarker("FMLServerStartedEvent", logger));
-        MinecraftForge.EVENT_BUS.addListener((FMLServerStoppingEvent event) -> logLifecycleMarker("FMLServerStoppingEvent", logger));
-        MinecraftForge.EVENT_BUS.addListener((FMLServerStoppedEvent event) -> logLifecycleMarker("FMLServerStoppedEvent", logger));
+        MinecraftForge.EVENT_BUS.addListener((FMLServerStartingEvent event) -> logLifecycleMarker(LogFlag.DIAGNOSTICS, "FMLServerStartingEvent", logger));
+        MinecraftForge.EVENT_BUS.addListener((FMLServerStartedEvent event) -> logLifecycleMarker(LogFlag.DIAGNOSTICS, "FMLServerStartedEvent", logger));
+        MinecraftForge.EVENT_BUS.addListener((FMLServerStoppingEvent event) -> logLifecycleMarker(LogFlag.DIAGNOSTICS, "FMLServerStoppingEvent", logger));
+        MinecraftForge.EVENT_BUS.addListener((FMLServerStoppedEvent event) -> logLifecycleMarker(LogFlag.DIAGNOSTICS, "FMLServerStoppedEvent", logger));
     }
 
-    private static void logLifecycleMarker(String stage, Logger logger) {
-        logger.info("{} Event fired: {}", DEBUG_PREFIX, stage);
+    private static void logLifecycleMarker(LogFlag flag, String stage, Logger logger) {
+        logger.info("{} Event fired: {}", formatPrefix(flag), stage);
     }
 
-    private static void logRuntimeDetails(Logger logger) {
+    private static void logRuntimeDetails(LogFlag flag, Logger logger) {
         RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
         List<String> inputArguments = runtimeMXBean.getInputArguments();
-        logger.info("{} Java version: {}", DEBUG_PREFIX, System.getProperty("java.version"));
-        logger.info("{} JVM name: {}", DEBUG_PREFIX, runtimeMXBean.getVmName());
-        logger.info("{} JVM vendor: {}", DEBUG_PREFIX, runtimeMXBean.getVmVendor());
-        logger.info("{} Launch arguments: {}", DEBUG_PREFIX, inputArguments);
+        String prefix = formatPrefix(flag);
+        logger.info("{} Java version: {}", prefix, System.getProperty("java.version"));
+        logger.info("{} JVM name: {}", prefix, runtimeMXBean.getVmName());
+        logger.info("{} JVM vendor: {}", prefix, runtimeMXBean.getVmVendor());
+        logger.info("{} Launch arguments: {}", prefix, inputArguments);
+    }
+
+    private static String formatPrefix(LogFlag flag) {
+        return DEBUG_PREFIX + flag.format();
     }
 
     @FunctionalInterface

--- a/src/main/java/com/xsasakihaise/hellasforms/diagnostics/LogFlag.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/diagnostics/LogFlag.java
@@ -1,0 +1,36 @@
+package com.xsasakihaise.hellasforms.diagnostics;
+
+/**
+ * Enumeration of logging flags used to identify which logical subsystem
+ * produced a message. Each flag renders as an upper-case token so that log
+ * statements can be filtered easily when debugging issues reported by users.
+ */
+public enum LogFlag {
+    CORE("CORE"),
+    API("API"),
+    CONFIG("CONFIG"),
+    COMMANDS("COMMANDS"),
+    ITEMS("ITEMS"),
+    BATTLES("BATTLES"),
+    LISTENERS("LISTENERS"),
+    DIAGNOSTICS("DIAGNOSTICS");
+
+    private final String token;
+
+    LogFlag(String token) {
+        this.token = token;
+    }
+
+    /**
+     * Returns the formatted flag that will be appended to the debug prefix in
+     * log statements.
+     */
+    public String format() {
+        return "[" + token + "]";
+    }
+
+    @Override
+    public String toString() {
+        return format();
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a LogFlag enum so log messages identify their subsystem
- update DebuggingHooks to include subsystem flags in all tracing output
- categorize HellasForms initialization and event hooks with granular runWithTracing calls

## Testing
- `./gradlew check` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_69054a7a5e6483319d42dae0b7d336b8