### PR TITLE
Handle Pixelmon API changes for bottle cap interaction

### DIFF
--- a/src/main/java/com/xsasakihaise/hellasforms/HellasFormsSetup.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/HellasFormsSetup.java
@@ -1,7 +1,10 @@
 package com.xsasakihaise.hellasforms;
 
-import com.pixelmonmod.pixelmon.api.interactions.InteractionRegistry;
 import com.xsasakihaise.hellasforms.interactions.InteractionBottleCap;
+import com.pixelmonmod.pixelmon.api.interactions.IInteraction;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.function.Supplier;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
@@ -10,6 +13,52 @@ import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 public final class HellasFormsSetup {
     @SubscribeEvent
     public static void onCommonSetup(final FMLCommonSetupEvent e) {
-        e.enqueueWork(() -> InteractionRegistry.register(new InteractionBottleCap()));
+        e.enqueueWork(() -> registerInteraction(new InteractionBottleCap()));
+    }
+
+    private static void registerInteraction(final IInteraction interaction) {
+        if (tryRegister(interaction, "com.pixelmonmod.pixelmon.api.interactions.InteractionRegistry", "register")) {
+            return;
+        }
+        if (tryRegister(interaction, "com.pixelmonmod.pixelmon.api.interactions.InteractionController", "register")) {
+            return;
+        }
+        if (tryRegister(interaction, "com.pixelmonmod.pixelmon.api.interactions.InteractionController", "registerInteraction")) {
+            return;
+        }
+        HellasForms.LOGGER.error("Unable to register Pixelmon interaction {} - no compatible registry methods found", interaction.getClass().getName());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean tryRegister(final IInteraction interaction, final String className, final String methodName) {
+        try {
+            final Class<?> registryClass = Class.forName(className);
+            final Class<?> interactionType = Class.forName("com.pixelmonmod.pixelmon.api.interactions.IInteraction");
+            final Method method = Arrays.stream(registryClass.getMethods())
+                    .filter(m -> m.getName().equals(methodName))
+                    .filter(m -> m.getParameterCount() == 1)
+                    .findFirst()
+                    .orElse(null);
+            if (method == null) {
+                return false;
+            }
+            final Class<?> parameterType = method.getParameterTypes()[0];
+            Object argument = null;
+            if (parameterType.isInstance(interaction) || parameterType.isAssignableFrom(interaction.getClass())
+                    || parameterType.isAssignableFrom(interactionType)) {
+                argument = interaction;
+            } else if (Supplier.class.isAssignableFrom(parameterType)) {
+                argument = (Supplier<IInteraction>) () -> interaction;
+            }
+            if (argument == null) {
+                return false;
+            }
+            method.invoke(null, argument);
+            HellasForms.LOGGER.debug("Registered Pixelmon interaction {} via {}#{}", interaction.getClass().getName(), className, methodName);
+            return true;
+        } catch (final ReflectiveOperationException ex) {
+            HellasForms.LOGGER.debug("Failed to register Pixelmon interaction {} via {}#{}", interaction.getClass().getName(), className, methodName, ex);
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- register the bottle cap interaction via reflective lookups to support multiple Pixelmon API versions
- update the interaction logic for the latest Minecraft/Pixelmon mappings and resolve owner UUID access via reflection

## Testing
- ./gradlew tasks --all *(fails: Forbidden downloading required dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_690562dfe50c833199bd81d3bfa8eef5