### PR TITLE
Bump project version to 2.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id("com.github.johnrengelman.shadow") version "8.1.1"
 }
 
-version = "2.5.0"
+version = "2.6.0"
 group = "com.xsasakihaise.hellasforms"
 
 base {

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -5,7 +5,7 @@ license="Restricted"
 
 [[mods]]
 modId="hellasforms"
-version="2.5.0"
+version="2.6.0"
 displayName="HellasForms"
 displayURL="https://discord.pixelmon-server.com"
 credits="xSasaki_Haise, pg13snipez, xGlitzerschaf, NouveauLumière"

--- a/src/main/resources/config/hellasforms.json
+++ b/src/main/resources/config/hellasforms.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.5.0",
+  "version": "2.6.0",
   "dependencies": ["Required:","- Forge 36.2.42+", "- Pixelmon 9.1.13+", "Tinkers Construct 3.3.0+", "- HellasContol 1.0.0+", "Optional:", "- HellasPatcher", "- HellasDeck", "- HellasElo"],
   "features": ["- Hellasian Regional Forms", "- Hellasian Regional Abilities", "- Hellasian Regional Moves", "- Hellasian Themed Items", "- Hellasian Regional Form Skins", "And much more..."]
 }


### PR DESCRIPTION
## Summary
- update the Gradle project version to 2.6.0
- align mods.toml metadata and configuration JSON with the new 2.6.0 release number

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905822b65f48331996e299bb1a9044d