### PR TITLE
Fix RegistryObject imports for Forge 1.16.5

### DIFF
--- a/src/main/java/com/xsasakihaise/hellasforms/candy/ModFluids.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/candy/ModFluids.java
@@ -16,7 +16,7 @@ import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.RegistryObject;
+import net.minecraftforge.fml.RegistryObject;
 
 /**
  * Registers the HellasForms fluid set (source + flowing + block + bucket) used by the EXP and attribute systems.

--- a/src/main/java/com/xsasakihaise/hellasforms/candy/ModItems.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/candy/ModItems.java
@@ -9,7 +9,7 @@ import net.minecraft.item.ItemGroup;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.RegistryObject;
+import net.minecraftforge.fml.RegistryObject;
 
 /**
  * Registers the HellasForms candies, casts, pellets, capsules and related crafting items.


### PR DESCRIPTION
## Summary
- update candy item and fluid registries to use net.minecraftforge.fml.RegistryObject to match Forge 1.16.5 package layout

## Testing
- `./gradlew compileJava` *(fails: unable to download Minecraft dependencies due to HTTP 403 responses in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_6907d60d2e388331b160cd58f1c75212