### PR TITLE
Add Lunar Ball localization strings

### DIFF
--- a/src/main/resources/assets/hellasforms/lang/de_de.json
+++ b/src/main/resources/assets/hellasforms/lang/de_de.json
@@ -40,6 +40,8 @@
     "item.pixelmon.ability_patch_remover": "Fähigkeitenpflaster-Entferner",
     "item.pixelmon.ability_patch_remover.tooltip": "Klicke mit der rechten Maustaste auf ein Pokémon, um seine Versteckte Fähigkeit zu entfernen und ihm eine zufällige Standardfähigkeit zu geben.",
     "item.pixelmon.ability_patch_remover.success": "%s hat seine Versteckte Fähigkeit abgelegt!",
+    "item.pixelmon.lunar_ball": "Lunarkugel",
+    "item.pixelmon.lunar_ball.tooltip": "Ein mit Mondlicht erfüllter Pokéball. Wirkt nachts am besten, besonders bei Vollmond.",
     "item.hellasforms.generic.no_effect": "%s wurde nicht beeinflusst.",
     "item.hellasforms.generic.ev_max": "Die EVs von %s sind für diesen Wert bereits am Maximum.",
     "item.hellasforms.generic.ability_fail": "%s kann seine aktuelle Fähigkeit nicht vergessen.",

--- a/src/main/resources/assets/hellasforms/lang/el_gr.json
+++ b/src/main/resources/assets/hellasforms/lang/el_gr.json
@@ -40,6 +40,8 @@
     "item.pixelmon.ability_patch_remover": "Αφαιρετής Επιθέματος Ικανότητας",
     "item.pixelmon.ability_patch_remover.tooltip": "Κάνε δεξί κλικ σε ένα Pokémon για να αφαιρέσεις την κρυφή ικανότητά του και να του δώσεις μια τυχαία βασική.",
     "item.pixelmon.ability_patch_remover.success": "%s εγκατέλειψε την κρυφή ικανότητά του!",
+    "item.pixelmon.lunar_ball": "Μπάλα Σελήνης",
+    "item.pixelmon.lunar_ball.tooltip": "Μια Poké Ball εμποτισμένη με φεγγαρόφως. Λειτουργεί καλύτερα τη νύχτα, ειδικά όταν έχει πανσέληνο.",
     "item.hellasforms.generic.no_effect": "%s δεν επηρεάστηκε.",
     "item.hellasforms.generic.ev_max": "Τα EV του %s είναι ήδη στο μέγιστο για αυτό το στατιστικό.",
     "item.hellasforms.generic.ability_fail": "%s δεν μπορεί να ξεχάσει την τωρινή του ικανότητα.",

--- a/src/main/resources/assets/hellasforms/lang/en_pt.json
+++ b/src/main/resources/assets/hellasforms/lang/en_pt.json
@@ -42,6 +42,8 @@
         "item.pixelmon.ability_patch_remover": "Αβιλιτψ Πατχη Ρεμονερ",
         "item.pixelmon.ability_patch_remover.tooltip": "Ριγητ-κλικκ α Ποκεμον το στριπ ιτσ ηιδδεν αβιλιτψ ανδ γραντ α ρανδομ στανδαρδ αβιλιτψ.",
         "item.pixelmon.ability_patch_remover.success": "%σ λετ γο οφ ιτσ ηιδδεν αβιλιτψ!",
+        "item.pixelmon.lunar_ball": "Λυναρ Βαλλ",
+        "item.pixelmon.lunar_ball.tooltip": "Α Ποκε Βαλλ ινφυσεδ ωιτη μουνλιγητ. Ωορκσ βεστ ατ νιγητ, εσπεκιαλλψ υνδερ α φυλλ μουν.",
 
         "item.hellasforms.generic.no_effect": "%σ ωασν'τ αφφεχτεδ.",
         "item.hellasforms.generic.ev_max": "%σ'σ ΕVσ αρε αλρεαδψ μαξεδ φορ τηατ στατ.",

--- a/src/main/resources/assets/hellasforms/lang/en_us.json
+++ b/src/main/resources/assets/hellasforms/lang/en_us.json
@@ -45,6 +45,8 @@
         "item.pixelmon.ability_patch_remover": "Ability Patch Remover",
         "item.pixelmon.ability_patch_remover.tooltip": "Right-click a Pokémon to strip its hidden ability and grant a random standard ability.",
         "item.pixelmon.ability_patch_remover.success": "%s let go of its hidden ability!",
+        "item.pixelmon.lunar_ball": "Lunar Ball",
+        "item.pixelmon.lunar_ball.tooltip": "A Poké Ball infused with moonlight. Works best at night, especially under a full moon.",
 
         "fluid.hellasforms.liquid_exp_candy": "Liquid EXP Candy",
         "fluid.hellasforms.liquid_str": "Liquid Strength",

--- a/src/main/resources/assets/hellasforms/lang/es_es.json
+++ b/src/main/resources/assets/hellasforms/lang/es_es.json
@@ -40,6 +40,8 @@
     "item.pixelmon.ability_patch_remover": "Eliminador de Parche Habilidad",
     "item.pixelmon.ability_patch_remover.tooltip": "Haz clic derecho sobre un Pokémon para quitarle la habilidad oculta y darle una habilidad estándar aleatoria.",
     "item.pixelmon.ability_patch_remover.success": "¡%s renunció a su habilidad oculta!",
+    "item.pixelmon.lunar_ball": "Bola Lunar",
+    "item.pixelmon.lunar_ball.tooltip": "Una Poké Ball impregnada de luz lunar. Funciona mejor de noche, sobre todo con luna llena.",
     "item.hellasforms.generic.no_effect": "%s no sufrió ningún efecto.",
     "item.hellasforms.generic.ev_max": "Los EV de %s ya están al máximo para esa estadística.",
     "item.hellasforms.generic.ability_fail": "%s no puede olvidar su habilidad actual.",

--- a/src/main/resources/assets/hellasforms/lang/fr_fr.json
+++ b/src/main/resources/assets/hellasforms/lang/fr_fr.json
@@ -40,6 +40,8 @@
     "item.pixelmon.ability_patch_remover": "Effaceur de Patch Talent",
     "item.pixelmon.ability_patch_remover.tooltip": "Clique droit sur un Pokémon pour lui retirer son talent caché et lui donner un talent standard aléatoire.",
     "item.pixelmon.ability_patch_remover.success": "%s a renoncé à son talent caché !",
+    "item.pixelmon.lunar_ball": "Lune Ball",
+    "item.pixelmon.lunar_ball.tooltip": "Une Poké Ball imprégnée de clair de lune. Fonctionne mieux la nuit, surtout lors de la pleine lune.",
     "item.hellasforms.generic.no_effect": "%s n'a subi aucun effet.",
     "item.hellasforms.generic.ev_max": "Les EV de %s sont déjà au maximum pour cette statistique.",
     "item.hellasforms.generic.ability_fail": "%s ne peut pas oublier son talent actuel.",

--- a/src/main/resources/assets/hellasforms/lang/it_it.json
+++ b/src/main/resources/assets/hellasforms/lang/it_it.json
@@ -40,6 +40,8 @@
     "item.pixelmon.ability_patch_remover": "Rimuovi-Cerotto Abilità",
     "item.pixelmon.ability_patch_remover.tooltip": "Fai clic destro su un Pokémon per rimuovere l'abilità speciale e dargli una abilità standard casuale.",
     "item.pixelmon.ability_patch_remover.success": "%s ha rinunciato alla sua abilità speciale!",
+    "item.pixelmon.lunar_ball": "Sfera Lunare",
+    "item.pixelmon.lunar_ball.tooltip": "Una Poké Ball intrisa di chiaro di luna. Funziona al meglio di notte, soprattutto con la luna piena.",
     "item.hellasforms.generic.no_effect": "%s non ne ha risentito.",
     "item.hellasforms.generic.ev_max": "Gli EV di %s sono già al massimo per quella statistica.",
     "item.hellasforms.generic.ability_fail": "%s non può dimenticare l'abilità attuale.",

--- a/src/main/resources/assets/hellasforms/lang/ja_jp.json
+++ b/src/main/resources/assets/hellasforms/lang/ja_jp.json
@@ -40,6 +40,8 @@
     "item.pixelmon.ability_patch_remover": "とくせいパッチリムーバー",
     "item.pixelmon.ability_patch_remover.tooltip": "ポケモンを右クリックして隠れ特性を消し、ランダムな通常特性を与えよう。",
     "item.pixelmon.ability_patch_remover.success": "%sは隠れ特性を手放した！",
+    "item.pixelmon.lunar_ball": "ルナーボール",
+    "item.pixelmon.lunar_ball.tooltip": "月光を宿した特別なモンスターボール。夜、とくに満月のときに最高の効果を発揮する。",
     "item.hellasforms.generic.no_effect": "%sには効果がなかった。",
     "item.hellasforms.generic.ev_max": "%sのきそポイントはその能力値ですでに最大だ。",
     "item.hellasforms.generic.ability_fail": "%sは今の特性を忘れられない。",

--- a/src/main/resources/assets/hellasforms/lang/ko_kr.json
+++ b/src/main/resources/assets/hellasforms/lang/ko_kr.json
@@ -40,6 +40,8 @@
     "item.pixelmon.ability_patch_remover": "특성패치 제거제",
     "item.pixelmon.ability_patch_remover.tooltip": "포켓몬을 오른쪽 클릭하여 숨겨진 특성을 지우고 무작위 일반 특성을 부여한다.",
     "item.pixelmon.ability_patch_remover.success": "%s는 숨겨진 특성을 버렸다!",
+    "item.pixelmon.lunar_ball": "루나볼",
+    "item.pixelmon.lunar_ball.tooltip": "달빛이 스며든 특별한 몬스터볼입니다. 밤, 특히 보름달일 때 가장 효과가 좋습니다.",
     "item.hellasforms.generic.no_effect": "%s는 아무 영향도 받지 않았다.",
     "item.hellasforms.generic.ev_max": "%s의 노력치는 이미 그 능력치에서 최대치다.",
     "item.hellasforms.generic.ability_fail": "%s는 현재 특성을 잊을 수 없다.",

--- a/src/main/resources/assets/hellasforms/lang/pl_pl.json
+++ b/src/main/resources/assets/hellasforms/lang/pl_pl.json
@@ -40,6 +40,8 @@
     "item.pixelmon.ability_patch_remover": "Zmywacz Łaty Umiejętności",
     "item.pixelmon.ability_patch_remover.tooltip": "Kliknij prawym przyciskiem na Pokémonie, aby zabrać mu ukrytą umiejętność i nadać losową zwykłą.",
     "item.pixelmon.ability_patch_remover.success": "%s pozbył się swojej ukrytej umiejętności!",
+    "item.pixelmon.lunar_ball": "Kula Lunarna",
+    "item.pixelmon.lunar_ball.tooltip": "Poké Ball nasączony blaskiem księżyca. Najlepiej działa nocą, zwłaszcza podczas pełni.",
     "item.hellasforms.generic.no_effect": "%s nie został dotknięty.",
     "item.hellasforms.generic.ev_max": "EV %s są już maksymalne dla tej statystyki.",
     "item.hellasforms.generic.ability_fail": "%s nie może zapomnieć swojej obecnej umiejętności.",

--- a/src/main/resources/assets/hellasforms/lang/pt_br.json
+++ b/src/main/resources/assets/hellasforms/lang/pt_br.json
@@ -40,6 +40,8 @@
     "item.pixelmon.ability_patch_remover": "Removedor de Patch de Habilidade",
     "item.pixelmon.ability_patch_remover.tooltip": "Clique com o botão direito em um Pokémon para remover a habilidade oculta e conceder uma habilidade padrão aleatória.",
     "item.pixelmon.ability_patch_remover.success": "%s abriu mão de sua habilidade oculta!",
+    "item.pixelmon.lunar_ball": "Bola Lunar",
+    "item.pixelmon.lunar_ball.tooltip": "Uma Poké Bola imbuída de luar. Funciona melhor à noite, especialmente sob a lua cheia.",
     "item.hellasforms.generic.no_effect": "%s não foi afetado.",
     "item.hellasforms.generic.ev_max": "Os EVs de %s já estão no máximo para esse atributo.",
     "item.hellasforms.generic.ability_fail": "%s não consegue esquecer a habilidade atual.",


### PR DESCRIPTION
## Summary
- add Lunar Ball name and tooltip translations to every provided locale
- describe the moonlight catch bonus so the Poké Ball reads correctly in each language

## Testing
- python - <<'PY'
import json,glob
for path in glob.glob('src/main/resources/assets/hellasforms/lang/*.json'):
    with open(path, encoding='utf-8') as f:
        json.load(f)
print('ok')
PY

------
https://chatgpt.com/codex/tasks/task_e_69094821af848331841c7ba1c932d45c