### PR TITLE
Add missing Lunar Ball datapack metadata

### DIFF
--- a/src/main/resources/assets/hellasforms/lang/en_us.json
+++ b/src/main/resources/assets/hellasforms/lang/en_us.json
@@ -18,6 +18,8 @@
         "item.pixelmon.rusted_bottle_cap.success": "%s's was corroded by the Rusted Bottle Cap!",
         "pixelmon.interaction.bottlecap.level": "%s needs to be at least Lv. 50.",
         "pixelmon.interaction.bottlecap.full": "%s cannot be hyper trained further.",
+        "item.pixelmon.lunar_ball": "Lunar Ball",
+        "item.pixelmon.lunar_ball.tooltip": "A Poké Ball that grows stronger under the full moon.",
         "item.pixelmon.exp_candy_xxl": "Exp. Candy XXL",
         "item.pixelmon.exp_candy_xxl.tooltip": "Right-click a Pokémon to grant it a tremendous 60,000 experience points.",
         "item.pixelmon.exp_candy_xxl.success": "%s absorbed the candy's colossal energy!",

--- a/src/main/resources/data/pixelmon/pokeballs/lunar_ball.json
+++ b/src/main/resources/data/pixelmon/pokeballs/lunar_ball.json
@@ -6,11 +6,16 @@
   "ballSprite": "pixelmon:textures/items/pokeballs/lunar_ball.png",
   "lidSprite": "pixelmon:textures/items/pokeballs/lids/lunar_ball.png",
   "guiSprite": "pixelmon:textures/gui/pokeballs/lunar_ball.png",
+  "bases": [
+    "pixelmon:black_apricorn",
+    "pixelmon:cooked_blue_apricorn"
+  ],
   "captureMethod": "gen8",
   "catchBonus": 1.0,
   "breakChance": 1.0,
   "velocityModifier": 1.0,
   "gravityModifier": 1.0,
   "particles": { "primary": "#8ec5ff", "secondary": "#d6b3ff" },
+  "translationKey": "item.pixelmon.lunar_ball",
   "logic": "hellasforms.pokeballs.LunarBallLogic"
 }


### PR DESCRIPTION
## Summary
- add the missing Lunar Ball base item references and translation key so the datapack JSON matches Pixelmon's expectations
- provide localisation strings for the Lunar Ball so the new translation key resolves in-game

## Testing
- `./gradlew build` *(fails: unable to download Minecraft client dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_690948676b1883319a94cb82b442947c