### PR TITLE
Fix lunar ball datapack particles format

### DIFF
--- a/src/main/resources/data/pixelmon/pokeballs/lunar_ball.json
+++ b/src/main/resources/data/pixelmon/pokeballs/lunar_ball.json
@@ -15,7 +15,7 @@
   "breakChance": 1.0,
   "velocityModifier": 1.0,
   "gravityModifier": 1.0,
-  "particles": { "primary": "#8ec5ff", "secondary": "#d6b3ff" },
+  "particles": false,
   "translationKey": "item.pixelmon.lunar_ball",
   "logic": "hellasforms.pokeballs.LunarBallLogic"
 }


### PR DESCRIPTION
## Summary
- replace the lunar ball datapack particle definition with a boolean flag so Pixelmon can parse it

## Testing
- `./gradlew build` *(fails: missing local dependency C:/Users/raehr/Documents/Hellas/HellasControl/build/libs/hellascontrol-1.0.0.jar)*

------
https://chatgpt.com/codex/tasks/task_e_69094d36552c833181bc4cea5242dce1