### PR TITLE
Use base PQC for Lunar Ball

### DIFF
--- a/src/main/resources/data/pixelmon/pokeballs/lunar_ball.json
+++ b/src/main/resources/data/pixelmon/pokeballs/lunar_ball.json
@@ -1,15 +1,15 @@
 {
   "name": "hellasforms:lunar_ball",
-  "model": "pixelmon:models/pokeballs/poke_ball.pqc",
+  "model": "pixelmon:models/pokeballs/base.pqc",
   "texture": "hellasforms:textures/entity/pokeballs/lunar_ball.png",
   "flashingTexture": "hellasforms:textures/entity/pokeballs/lunar_ball_flash.png",
   "ballSprite": "hellasforms:textures/items/pokeballs/lunar_ball.png",
   "lidSprite": "hellasforms:textures/items/pokeballs/lids/lunar_ball.png",
   "guiSprite": "hellasforms:textures/gui/pokeballs/lunar_ball.png",
-    "bases": [
-      "pixelmon:cooked_black_apricorn",
-      "pixelmon:cooked_blue_apricorn"
-    ],
+  "bases": [
+    "pixelmon:cooked_black_apricorn",
+    "pixelmon:cooked_blue_apricorn"
+  ],
   "captureMethod": "gen8",
   "catchBonus": 1.0,
   "breakChance": 1.0,


### PR DESCRIPTION
## Summary
- swap the Lunar Ball definition to use `pixelmon:models/pokeballs/base.pqc`
- keep the Lunar Ball item and lid texture references pointing at the custom Hellasforms paths

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6909713771ac8331a72f718764505bba