### PR TITLE
Fix Lunar Ball recipes to use lunar lid

### DIFF
--- a/src/main/resources/data/pixelmon/recipes/pokeball/ball/lunar_ball.json
+++ b/src/main/resources/data/pixelmon/recipes/pokeball/ball/lunar_ball.json
@@ -2,8 +2,7 @@
   "type": "minecraft:crafting_shapeless",
   "ingredients": [
     {
-      "item": "pixelmon:poke_ball_lid",
-      "nbt": "{PokeBallID:\"hellasforms:lunar_ball\"}"
+      "item": "pixelmon:lunar_ball_lid"
     },
     {
       "item": "pixelmon:silver_base"

--- a/src/main/resources/data/pixelmon/recipes/pokeball/lid/lunar_ball.json
+++ b/src/main/resources/data/pixelmon/recipes/pokeball/lid/lunar_ball.json
@@ -8,8 +8,7 @@
     "B": { "item": "pixelmon:cooked_black_apricorn" }
   },
   "result": {
-    "item": "pixelmon:poke_ball_lid",
-    "count": 1,
-    "nbt": "{PokeBallID:\"hellasforms:lunar_ball\"}"
+    "item": "pixelmon:lunar_ball_lid",
+    "count": 1
   }
 }


### PR DESCRIPTION
## Summary
- require the dedicated lunar ball lid item when crafting the Lunar Ball
- have the lid crafting recipe output the lunar ball lid item instead of the generic Poké Ball lid

## Testing
- ./gradlew build *(fails: Cannot convert URL 'C:/Users/raehr/Documents/Hellas/HellasControl/build/libs/hellascontrol-1.0.0.jar' to a file)*

------
https://chatgpt.com/codex/tasks/task_e_690995a049948331b4ad71133cc527bc