### PR TITLE
Document HellasForms features and APIs

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,88 @@
+# HellasForms
+
+HellasForms is the content-heavy sidemod that powers the custom forms, items,
+and battle rules that define the Hellas Pixelmon experience. It layers bespoke
+abilities, moves, battle listeners and staff tools on top of Pixelmon so
+builders can ship event lines, crate rewards and seasonal mechanics without
+patching the base mod.
+
+## Feature highlights
+- **Custom battle content** – `battles.*` introduces move effects, multistage
+  attacks and battlefield statuses referenced by Pixelmon JSON move configs, and
+  `api.pokemon.ability.abilities` contains the bespoke abilities tied to the
+  Hellasian forms.
+- **Pokemon-facing consumables** – The `items.consumables` package provides
+  reusable base logic (`PokemonInteractItem`) plus concrete items like EXP
+  candies, EV maximisers and the ability patch remover that talk to Pokemon
+  instances directly.
+- **Quest and reward items** – Eggs, ores and battle pass vouchers (`BattlePassItem`,
+  `PokemonEggItem`, `OreItem`) integrate with LuckPerms or `pokegive` to deliver
+  server rewards while respecting Pixelmon's quest item semantics.
+- **Staff-friendly interactions** – Interaction and listener packages register
+  hooks like the bottle cap GUI, guaranteed item returns in staff battles, and
+  growth rarity tuning so events behave predictably.
+- **Candy crafting components** – `candy.ModItems` and `candy.ModFluids`
+  register the casts, pellets, liquid EXP and attribute fluids used by the Hellas
+  candy economy, complete with buckets and placeable fluid blocks.
+- **Diagnostics and entitlement checks** – `diagnostics.DebuggingHooks` and the
+  startup flow verify that HellasCore is present, gate features behind the
+  "forms" entitlement key and emit verbose lifecycle logs to simplify support.
+
+## Technical overview
+The entry point is `com.xsasakihaise.hellasforms.HellasForms`, annotated with
+`@Mod`, which installs the debugging hooks, registers all Forge/Pixelmon content
+and wires listeners into the Forge and Pixelmon event buses. Pixelmon-specific
+registrations (mega stones, badges, quest items) go through
+`ItemRegistration.ITEMS` while standard Forge content uses deferred registers
+(`ModItems`, `ModFluids`, `HellasForms.ITEMS`).
+
+Domain-specific packages include:
+- `battles.attacks` and `battles.status` for move logic and status effects.
+- `api.pokemon.ability.abilities` for AbstractAbility implementations referenced
+  by the custom forms.
+- `items.consumables`/`items.heldItems`/`interactions` for reward items that
+  manipulate Pokemon data via Pixelmon's API or command layer.
+- `listener` for Forge/Pixelmon event handlers that tweak growth odds and battle
+  behaviour.
+- `diagnostics` for logging/tracing utilities invoked at every lifecycle stage.
+
+Mixins under `mixin.abilities.effects` overwrite Pixelmon abilities such as
+Strong Jaw and Sharpness so Hellas-exclusive moves are recognised without
+maintaining a fork.
+
+## Extension points
+- **New Pokemon consumables** – Extend `PokemonInteractItem`, implement
+  `applyEffect` and `getSuccessMessage`, then register the item via
+  `HellasForms.ITEMS`. See `ExperienceCandyItem` for an example that works across
+  multiple Pixelmon API versions.
+- **Additional abilities or move effects** – Add classes under
+  `api.pokemon.ability.abilities` or `battles.attacks.specialAttacks` and ensure
+  the name is registered in `HellasForms` via `EffectTypeAdapter.EFFECTS`. The
+  Pixelmon move JSONs can then reference the new identifiers.
+- **Custom eggs or quest rewards** – Create a new item registration in
+  `HellasForms` and supply a matching loot table JSON under
+  `assets/hellasforms/eggs/<id>-data.json` (see `PokemonEggItem`).
+- **Candy fluids** – Follow the pattern in `candy.ModFluids.registerFluid` to
+  add a new `FluidSet`, then expose the `source`, `flowing`, `block` and
+  `bucket` registry objects.
+
+## Dependencies & environment
+- Minecraft 1.16.5
+- Forge 36.2.42 (configured via ForgeGradle 6 + Parchment mappings 2022.03.06)
+- Pixelmon Reforged 9.1.12
+- HellasControl (compile-time dependency, used for entitlement checks via
+  `CoreCheck`)
+- Java 8 toolchain
+
+## Notes for future migration
+- Battle move classes and mixins depend on Pixelmon internals like
+  `EffectTypeAdapter`, `PixelmonWrapper` and concrete ability classes. Updating to
+  a new Pixelmon major release will require auditing `battles.*` and
+  `mixin.abilities.effects` to ensure method signatures and move IDs remain
+  compatible.
+- `items.consumables.ExperienceCandyItem` and `AbilityPatchRemoverItem` rely on
+  reflection and command formats that may change between versions. Re-test these
+  flows after every Pixelmon update.
+- Bottle cap interactions (`interactions.InteractionBottleCap`) and the growth
+  listener manipulate enums and GUIs that are tightly coupled to the 1.16.5
+  client – any NeoForge/1.20 migration should revalidate those assumptions.

--- a/src/main/java/com/xsasakihaise/hellasforms/BattlePassItem.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/BattlePassItem.java
@@ -10,6 +10,12 @@ import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.world.World;
 
+/**
+ * Lightweight quest token that increments a player's LuckPerms track when used.
+ *
+ * <p>The integer suffix of the registry name (battlepass_item_1..20) determines
+ * which LP parent is added.</p>
+ */
 public class BattlePassItem extends QuestItem {
 
     public BattlePassItem() {
@@ -26,6 +32,7 @@ public class BattlePassItem extends QuestItem {
                 String numberStr = itemId.replace("battlepass_item_", "");
                 int bpNumber = Integer.parseInt(numberStr);
 
+                // Execute against LuckPerms so staff do not need to manually grant rewards.
                 String command = String.format("minecraft:lp user %s parent add bp%d",
                         player.getName().getString(), bpNumber);
 

--- a/src/main/java/com/xsasakihaise/hellasforms/HellasForms.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/HellasForms.java
@@ -41,6 +41,14 @@ import com.xsasakihaise.hellascontrol.api.CoreCheck;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.loading.FMLEnvironment;
 
+/**
+ * Main Forge/Pixelmon entry point for the HellasForms sidemod.
+ * <p>
+ * The mod focuses on content that expands the Pokemon roster for the Hellas project:
+ * custom forms, abilities, consumables, battle effects, debug hooks and convenience
+ * listeners.  Registration of Pixelmon adapters, Forge items, quest rewards and
+ * lifecycle listeners all originate from this class.
+ */
 @Mod("hellasforms")
 public class HellasForms {
 
@@ -56,6 +64,10 @@ public class HellasForms {
         ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, "hellasforms");
     }
 
+    /**
+     * Forge bootstrap hook. Performs entitlement checks, installs tracing utilities
+     * and registers every runtime component that belongs to the mod.
+     */
     public HellasForms() {
         DebuggingHooks.runWithTracing(LogFlag.API, "CoreCheck.verifyCoreLoaded()", LOGGER, CoreCheck::verifyCoreLoaded);
         if (FMLEnvironment.dist == Dist.DEDICATED_SERVER) {
@@ -79,6 +91,7 @@ public class HellasForms {
                 infoConfig.loadDefaultsFromResource();
             });
 
+            // Register every custom Pixelmon battle effect so JSON-driven moves can reference them by name.
             DebuggingHooks.runWithTracing(LogFlag.BATTLES, "registerBattleEffectAdapters", LOGGER, () -> {
                 EffectTypeAdapter.EFFECTS.put("ColonySwarm", ColonySwarm.class);
                 EffectTypeAdapter.EFFECTS.put("Corrode", Corrode.class);
@@ -107,6 +120,7 @@ public class HellasForms {
                 EffectTypeAdapter.EFFECTS.put("IcyImmolation", IcyImmolation.class);
             });
 
+            // Pixelmon's ItemRegistration handles quest items, mega stones and other non-Forge driven content.
             DebuggingHooks.runWithTracing(LogFlag.ITEMS, "registerPixelmonItems", LOGGER, () -> {
                 ItemRegistration.ITEMS.register("eeveeolite", EeveeoliteItem::new);
 
@@ -156,6 +170,7 @@ public class HellasForms {
                 ItemRegistration.ITEMS.register("pg_token", QuestItem::new);
             });
 
+            // Regular Forge items defined by this mod (eggs, ores, quest tokens).
             DebuggingHooks.runWithTracing(LogFlag.ITEMS, "registerHellasItems", LOGGER, () -> {
                 ITEMS.register("wild-egg", PokemonEggItem::new);
                 ITEMS.register("hellasian-egg", PokemonEggItem::new);
@@ -241,6 +256,10 @@ public class HellasForms {
         });
     }
 
+    /**
+     * Standard common setup callback. Used purely as a lifecycle marker because the
+     * heavy lifting already occurs inside the constructor.
+     */
     private void setup(FMLCommonSetupEvent event) {
         DebuggingHooks.runWithTracing(LogFlag.CORE, "setup(FMLCommonSetupEvent)", LOGGER, () ->
                 LOGGER.info("{} Loaded HellasForms (hopefully XD)", LogFlag.CORE.format()));
@@ -267,10 +286,20 @@ public class HellasForms {
     @SubscribeEvent
     public static void onServerStopped(FMLServerStoppedEvent event) { }
 
+    /**
+     * @return singleton mod instance for convenience lookups.
+     */
     public static HellasForms getInstance() { return instance; }
 
+    /**
+     * @return shared mod logger tagged with the mod id.
+     */
     public static Logger getLogger() { return LOGGER; }
 
+    /**
+     * Registers additional lifecycle listeners. Currently unused but kept for
+     * parity with older iterations of the mod bootstrap.
+     */
     public void ModEventSubscriber() {
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::commonSetup);
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::clientSetup);

--- a/src/main/java/com/xsasakihaise/hellasforms/HellasFormsInfoConfig.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/HellasFormsInfoConfig.java
@@ -13,6 +13,13 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
+/**
+ * Minimal JSON-backed config file that exposes metadata about the installed
+ * HellasForms build (version number, dependency list and exported features).
+ *
+ * <p>The file lives at {@code config/hellasforms.json} on a server install and
+ * mirrors the resource bundled with the mod if it does not exist yet.</p>
+ */
 public class HellasFormsInfoConfig {
     private transient final Gson gson = new GsonBuilder().setPrettyPrinting().create();
     private File configFile;
@@ -24,8 +31,9 @@ public class HellasFormsInfoConfig {
     private boolean valid = false;
 
     /**
-     * Lade Konfiguration aus dem Serververzeichnis (config/hellasforms.json).
-     * Falls nicht vorhanden oder ungültig, werden Defaults aus resources verwendet.
+     * Loads the configuration from the given server root directory.
+     * If the file does not exist (or fails to parse) a default copy from
+     * the mod resources will be used instead.
      */
     public void load(File serverRoot) {
         File configDir = new File(serverRoot, "config");
@@ -50,12 +58,12 @@ public class HellasFormsInfoConfig {
             }
         }
 
-        // Wenn keine gültige Serverdatei, Defaults nutzen
+        // Fallback to bundled defaults if we could not read a server side file.
         loadDefaultsFromResource();
     }
 
     /**
-     * Lade Default-Config aus Ressourcen: config/hellasforms.json (classpath).
+     * Populates the config object with the JSON file that ships with the mod jar.
      */
     public void loadDefaultsFromResource() {
         try (InputStream is = getClass().getClassLoader().getResourceAsStream("config/hellasforms.json")) {
@@ -79,6 +87,10 @@ public class HellasFormsInfoConfig {
         }
     }
 
+    /**
+     * @return {@code true} when the config information has been populated either
+     * from disk or from the default resource file.
+     */
     public boolean isValid() { return valid; }
 
     public void save() {
@@ -90,7 +102,18 @@ public class HellasFormsInfoConfig {
         }
     }
 
+    /**
+     * @return declared version string or a placeholder when not configured.
+     */
     public String getVersion() { return version != null ? version : "0.0.0"; }
+
+    /**
+     * @return the human readable dependency list advertised to server staff.
+     */
     public String[] getDependencies() { return dependencies != null ? dependencies : new String[0]; }
+
+    /**
+     * @return bullet-point friendly list of features (mirrors FEATURES.md contents).
+     */
     public String[] getFeatures() { return features != null ? features : new String[0]; }
 }

--- a/src/main/java/com/xsasakihaise/hellasforms/OreItem.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/OreItem.java
@@ -2,6 +2,10 @@ package com.xsasakihaise.hellasforms;
 
 import com.pixelmonmod.pixelmon.items.QuestItem;
 
+/**
+ * Generic quest item wrapper used for the many mineral drops stored inside
+ * Hellas crates. Exists so Pixelmon handles them as non-stackable quest items.
+ */
 public class OreItem extends QuestItem {
 
     public OreItem() {

--- a/src/main/java/com/xsasakihaise/hellasforms/PokemonEggItem.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/PokemonEggItem.java
@@ -17,6 +17,13 @@ import java.io.InputStreamReader;
 import java.lang.reflect.Type;
 import java.util.Map;
 
+/**
+ * Represents the different "mystery egg" quest rewards sold on Hellas servers.
+ *
+ * <p>Each egg looks up a JSON loot table under {@code assets/hellasforms/eggs}
+ * and grants a random Pokemon (sometimes shiny) by dispatching the appropriate
+ * Pixelmon {@code /pokegive} command.</p>
+ */
 public class PokemonEggItem extends QuestItem {
 
     public PokemonEggItem() {
@@ -39,6 +46,7 @@ public class PokemonEggItem extends QuestItem {
                     return ActionResult.success(stack);
                 }
 
+                // Eggs are defined as a simple map of "displayName -> pokemonSpec" pairs.
                 Type type = new TypeToken<Map<String, String>>() {}.getType();
                 Map<String, String> pokemonMap = new Gson().fromJson(new InputStreamReader(stream), type);
 

--- a/src/main/java/com/xsasakihaise/hellasforms/api/pokemon/ability/abilities/JadeEmperor.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/api/pokemon/ability/abilities/JadeEmperor.java
@@ -8,6 +8,10 @@ import com.pixelmonmod.pixelmon.battles.status.PsychicTerrain;
 import com.pixelmonmod.pixelmon.battles.status.Terrain;
 import com.pixelmonmod.pixelmon.enums.heldItems.EnumHeldItems;
 
+/**
+ * Ability used by custom forms that summons Psychic Terrain on switch-in and
+ * gains an additional stat boost whenever Misty Terrain is active.
+ */
 public class JadeEmperor extends AbstractAbility {
     public JadeEmperor() {
     }

--- a/src/main/java/com/xsasakihaise/hellasforms/candy/ModFluids.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/candy/ModFluids.java
@@ -66,6 +66,9 @@ public final class ModFluids {
         return set;
     }
 
+    /**
+     * Registers the fluid, block and bucket containers with the Forge bus.
+     */
     public static void register(IEventBus eventBus) {
         FLUIDS.register(eventBus);
         BLOCKS.register(eventBus);
@@ -84,18 +87,30 @@ public final class ModFluids {
             this.name = name;
         }
 
+        /**
+         * @return still fluid instance registered under this set's name.
+         */
         public ForgeFlowingFluid.Source getSourceFluid() {
             return source.get();
         }
 
+        /**
+         * @return flowing fluid variant (used for world rendering/physics).
+         */
         public ForgeFlowingFluid.Flowing getFlowingFluid() {
             return flowing.get();
         }
 
+        /**
+         * @return block representation so mappers can place it in the world.
+         */
         public FlowingFluidBlock getFluidBlock() {
             return block.get();
         }
 
+        /**
+         * @return bucket item tied to the source fluid.
+         */
         public Item getBucketItem() {
             return bucket.get();
         }

--- a/src/main/java/com/xsasakihaise/hellasforms/candy/ModItems.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/candy/ModItems.java
@@ -38,6 +38,10 @@ public final class ModItems {
     public static final RegistryObject<Item> PELLET_WIS = ITEMS.register("pellet_wis", () -> new Item(DEFAULT_PROPS));
     public static final RegistryObject<Item> PELLET_CHA = ITEMS.register("pellet_cha", () -> new Item(DEFAULT_PROPS));
 
+    /**
+     * Hooks every deferred register up to the provided mod event bus. Must be
+     * invoked during mod construction.
+     */
     public static void register(IEventBus eventBus) {
         ITEMS.register(eventBus);
     }

--- a/src/main/java/com/xsasakihaise/hellasforms/interactions/InteractionBottleCap.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/interactions/InteractionBottleCap.java
@@ -19,8 +19,16 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Hand;
 
+/**
+ * Custom interaction that mirrors Pixelmon's bottle cap UI but enforces a
+ * handful of Hellas-specific restrictions (owner only, level gate, IV summary).
+ */
 public class InteractionBottleCap implements IInteraction {
 
+    /**
+     * Opens the vanilla bottle cap GUI if the player meets all prerequisites and
+     * posts a {@link BottleCapEvent} for other mods to react to.
+     */
     @Override
     public boolean processInteract(PixelmonEntity pixelmon, PlayerEntity player, Hand hand, ItemStack stack) {
         if (player.level.isClientSide || hand == Hand.OFF_HAND || !(stack.getItem() instanceof BottlecapItem)) {

--- a/src/main/java/com/xsasakihaise/hellasforms/items/consumables/AbilityPatchRemoverItem.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/items/consumables/AbilityPatchRemoverItem.java
@@ -21,10 +21,13 @@ import java.lang.reflect.Method;
 import java.util.*;
 
 /**
- * Ability Patch Remover:
- * - If the Pokémon has a Hidden Ability, switch it to the first NORMAL (slot 0) ability.
- * - First tries to do it via /pokeedit (same execution path as BattlePass item).
- * - If commands fail (SP/LAN without perms or no dispatcher), falls back to PokemonSpec / direct API.
+ * Ability Patch Remover item.
+ * <ul>
+ *     <li>Detects whether the targeted Pokemon is currently on its Hidden Ability.</li>
+ *     <li>Attempts to switch back to ability slot 0 via {@code /pokeedit} command execution.</li>
+ *     <li>If command execution is unavailable, falls back to using {@code PokemonSpec}
+ *     or direct API manipulation to ensure the change still happens.</li>
+ * </ul>
  */
 public class AbilityPatchRemoverItem extends PokemonInteractItem {
 

--- a/src/main/java/com/xsasakihaise/hellasforms/items/consumables/EvMaximizerItem.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/items/consumables/EvMaximizerItem.java
@@ -9,6 +9,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
 
+/**
+ * Sets one EV stat to the Pixelmon cap (252) while respecting the overall total
+ * limit. Used to instantly perfect specific spreads for competitive play.
+ */
 public class EvMaximizerItem extends PokemonInteractItem {
     private final BattleStatsType targetStat;
     private final String successTranslation;
@@ -26,6 +30,7 @@ public class EvMaximizerItem extends PokemonInteractItem {
             return false;
         }
 
+        // Compute total EVs to ensure we do not violate the 510 cap.
         int total = 0;
         for (BattleStatsType statType : BattleStatsType.getEVIVStatValues()) {
             total += evStore.getStat(statType);

--- a/src/main/java/com/xsasakihaise/hellasforms/items/consumables/ExperienceCandyItem.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/items/consumables/ExperienceCandyItem.java
@@ -10,6 +10,11 @@ import net.minecraft.util.text.TranslationTextComponent;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+/**
+ * EXP candy variant that grants a configurable amount of experience to the
+ * targeted Pokemon. Reflection is used so it works across multiple Pixelmon
+ * builds where the EXP APIs moved between releases.
+ */
 public class ExperienceCandyItem extends PokemonInteractItem {
     private final int experienceAmount;
     private final String successTranslation;
@@ -34,6 +39,10 @@ public class ExperienceCandyItem extends PokemonInteractItem {
         return new TranslationTextComponent(successTranslation, pokemon.getDisplayName());
     }
 
+    /**
+     * Attempts several possible EXP APIs in order of preference so that the
+     * item remains functional regardless of obfuscation mappings.
+     */
     private boolean addExperience(Pokemon pokemon, int amount) {
         if (pokemon == null || amount <= 0) {
             return false;
@@ -48,6 +57,7 @@ public class ExperienceCandyItem extends PokemonInteractItem {
             }
         }
 
+        // Older builds exposed a nested experience store, newer ones used primitives.
         Object experienceObject = invoke(pokemon, "getExperience");
         if (experienceObject instanceof Number) {
             Method setter = findMethod(Pokemon.class, "setExperience", int.class);
@@ -94,6 +104,10 @@ public class ExperienceCandyItem extends PokemonInteractItem {
         }
     }
 
+    /**
+     * Utility that walks a class hierarchy for a declared method without
+     * assuming SRG or Mojang naming.
+     */
     private Method findMethod(Class<?> type, String name, Class<?>... parameterTypes) {
         if (type == null) {
             return null;

--- a/src/main/java/com/xsasakihaise/hellasforms/items/consumables/PokemonInteractItem.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/items/consumables/PokemonInteractItem.java
@@ -13,6 +13,8 @@ import net.minecraft.util.text.TranslationTextComponent;
 
 /**
  * Base class for consumables that interact directly with a targeted Pixelmon entity.
+ * Subclasses only need to provide the actual effect and the localized message that
+ * is sent back to the player when the interaction succeeds or fails.
  */
 public abstract class PokemonInteractItem extends QuestItem {
 
@@ -20,6 +22,10 @@ public abstract class PokemonInteractItem extends QuestItem {
         super();
     }
 
+    /**
+     * Handles the "use item on Pixelmon" interaction and delegates the actual
+     * effect to {@link #applyEffect(PlayerEntity, Pokemon, PixelmonEntity, ItemStack)}.
+     */
     @Override
     public ActionResultType interactLivingEntity(ItemStack stack, PlayerEntity player, LivingEntity target, Hand hand) {
         if (!(target instanceof PixelmonEntity)) {
@@ -50,11 +56,23 @@ public abstract class PokemonInteractItem extends QuestItem {
         return ActionResultType.sidedSuccess(player.level.isClientSide);
     }
 
+    /**
+     * @return localized fallback when {@link #applyEffect} returns false.
+     */
     protected ITextComponent getFailureMessage(Pokemon pokemon) {
         return new TranslationTextComponent("item.hellasforms.generic.no_effect", pokemon.getDisplayName());
     }
 
+    /**
+     * Applies the concrete effect (EV changes, experience, ability swapping, etc.).
+     *
+     * @return {@code true} when the stack should be consumed and the success
+     * message should be sent to the player.
+     */
     protected abstract boolean applyEffect(PlayerEntity player, Pokemon pokemon, PixelmonEntity entity, ItemStack stack);
 
+    /**
+     * @return localized message that explains what just happened to the Pokemon.
+     */
     protected abstract ITextComponent getSuccessMessage(Pokemon pokemon);
 }

--- a/src/main/java/com/xsasakihaise/hellasforms/items/heldItems/EeveeoliteItem.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/items/heldItems/EeveeoliteItem.java
@@ -6,6 +6,9 @@ import com.pixelmonmod.pixelmon.enums.heldItems.EnumHeldItems;
 import com.pixelmonmod.pixelmon.items.HeldItem;
 import net.minecraft.item.Item;
 
+/**
+ * Custom held item: doubles Eevee's Speed and Special Attack while held.
+ */
 public class EeveeoliteItem extends HeldItem {
     public EeveeoliteItem() {
         super(EnumHeldItems.other, new Item.Properties());

--- a/src/main/java/com/xsasakihaise/hellasforms/listener/GrowthSpawningListener.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/listener/GrowthSpawningListener.java
@@ -4,6 +4,10 @@ import com.pixelmonmod.pixelmon.enums.EnumGrowth;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.event.server.FMLServerStartedEvent;
 
+/**
+ * Adjusts the spawn rarity weights for every Pixelmon growth on server start.
+ * Makes the custom Hellas growth distributions feel more even across the size scale.
+ */
 public class GrowthSpawningListener {
     public GrowthSpawningListener() {
     }

--- a/src/main/java/com/xsasakihaise/hellasforms/listener/ReturnItemsListener.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/listener/ReturnItemsListener.java
@@ -6,6 +6,10 @@ import com.pixelmonmod.pixelmon.battles.controller.participants.PixelmonWrapper;
 import com.pixelmonmod.pixelmon.battles.controller.participants.WildPixelmonParticipant;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
+/**
+ * Ensures battle participants keep their held items after staff-organised duels.
+ * Wild encounters are ignored so the vanilla "item steal" behaviour still applies.
+ */
 public class ReturnItemsListener {
     public ReturnItemsListener() {
     }

--- a/src/main/java/com/xsasakihaise/hellasforms/mixin/abilities/effects/MixinSharpness.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/mixin/abilities/effects/MixinSharpness.java
@@ -10,6 +10,9 @@ import org.spongepowered.asm.mixin.Overwrite;
 
 import java.util.Set;
 
+/**
+ * Extends the Sharpness ability whitelist with Hellas-exclusive slicing moves.
+ */
 @Mixin({Sharpness.class})
 public class MixinSharpness extends AbstractAbility {
     @Overwrite(

--- a/src/main/java/com/xsasakihaise/hellasforms/mixin/abilities/effects/MixinStrongJaw.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/mixin/abilities/effects/MixinStrongJaw.java
@@ -10,6 +10,10 @@ import org.spongepowered.asm.mixin.Overwrite;
 
 import java.util.Set;
 
+/**
+ * Expands the Strong Jaw ability so it recognises Hellas custom fang moves.
+ * Implemented as a mixin overwrite because Pixelmon hardcodes the list.
+ */
 @Mixin({StrongJaw.class})
 public class MixinStrongJaw extends AbstractAbility {
     @Overwrite(


### PR DESCRIPTION
## Summary
- add repository-level FEATURES.md that describes the HellasForms sidemod, its components, and environment requirements
- document the mod entry point, consumable item base classes, listeners, mixins, and other public-facing APIs with Javadoc and inline comments
- annotate battle content, reward items, and registrations to clarify how new content hooks into Pixelmon

## Testing
- Not Run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691854096f308331806d413b2bb62f1f)