### PR TITLE
Validate form change tickets against available forms

### DIFF
--- a/src/main/java/com/xsasakihaise/hellasforms/items/consumables/FormChangeTicketItem.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/items/consumables/FormChangeTicketItem.java
@@ -27,7 +27,8 @@ public class FormChangeTicketItem extends PokemonInteractItem {
     @Override
     protected boolean applyEffect(PlayerEntity player, Pokemon pokemon, PixelmonEntity entity, ItemStack stack) {
         Form form = pokemon.getSpecies().getForm(targetForm);
-        if (form == null || pokemon.getForm().isForm(targetForm)) {
+        boolean hasTargetForm = form != null && form.getName().equalsIgnoreCase(targetForm);
+        if (!hasTargetForm || pokemon.getForm().isForm(targetForm)) {
             return false;
         }
 
@@ -43,7 +44,8 @@ public class FormChangeTicketItem extends PokemonInteractItem {
 
     @Override
     protected ITextComponent getFailureMessage(Pokemon pokemon) {
-        if (pokemon.getSpecies().getForm(targetForm) == null) {
+        Form form = pokemon.getSpecies().getForm(targetForm);
+        if (form == null || !form.getName().equalsIgnoreCase(targetForm)) {
             return new TranslationTextComponent("item.hellasforms.form_change.missing", pokemon.getDisplayName(), targetForm);
         }
         if (pokemon.getForm().isForm(targetForm)) {


### PR DESCRIPTION
## Summary
- ensure form change tickets only succeed when the target form actually exists
- align failure feedback with the stricter form availability check

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936c9a230ec8331a3975fb756b48fea)