### PR TITLE
Add JitPack HellasControl dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ repositories {
 
 
 dependencies {
-    compileOnly fileTree(dir: 'libs', include: 'hellascontrol-*.jar')
+    compileOnly fg.deobf('com.github.xSasakiHaise:hellascontrol:2.0.0')
     minecraft "net.minecraftforge:forge:1.16.5-36.2.42"
 
     implementation fg.deobf("pixelmon:Pixelmon-1.16.5-9.1.12-universal:9.1.12")


### PR DESCRIPTION
## Summary
- add the HellasControl 2.0.0 API via a JitPack compileOnly dependency to match the required integration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693eec6fd9508331b40af9aaf176e32e)