### PR TITLE
Fix HellasForms lifecycle registration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,8 @@ repositories {
 
 
 dependencies {
-    compileOnly fg.deobf('com.github.xSasakiHaise:hellascontrol:2.0.0')
+    // Use the correctly cased JitPack coordinate for HellasControl
+    compileOnly fg.deobf('com.github.xSasakiHaise:HellasControl:2.0.0')
     minecraft "net.minecraftforge:forge:1.16.5-36.2.42"
 
     implementation fg.deobf("pixelmon:Pixelmon-1.16.5-9.1.12-universal:9.1.12")

--- a/src/main/java/com/xsasakihaise/hellasforms/HellasForms.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/HellasForms.java
@@ -82,6 +82,8 @@ public class HellasForms {
             DebuggingHooks.runWithTracing(LogFlag.CORE, "registerLifecycleListeners", LOGGER, () -> {
                 IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
                 modEventBus.addListener(this::setup);
+                modEventBus.addListener(this::commonSetup);
+                modEventBus.addListener(this::clientSetup);
                 ModItems.register(modEventBus);
                 ModFluids.register(modEventBus);
                 MinecraftForge.EVENT_BUS.register(this);
@@ -257,7 +259,7 @@ public class HellasForms {
                 ITEMS.register("hellas_turquoise", OreItem::new);
                 ITEMS.register("hellas_yellow_flourite", OreItem::new);
 
-                ITEMS.register(FMLJavaModLoadingContext.get().getModEventBus());
+                ITEMS.register(modEventBus);
             });
         });
     }
@@ -302,23 +304,12 @@ public class HellasForms {
      */
     public static Logger getLogger() { return LOGGER; }
 
-    /**
-     * Registers additional lifecycle listeners. Currently unused but kept for
-     * parity with older iterations of the mod bootstrap.
-     */
-    public void ModEventSubscriber() {
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::commonSetup);
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::clientSetup);
-    }
-
-    @SubscribeEvent
     public void commonSetup(FMLCommonSetupEvent event) {
         DebuggingHooks.runWithTracing(LogFlag.CORE, "commonSetup(FMLCommonSetupEvent)", LOGGER, () -> {
             // Intentionally blank hook for future use
         });
     }
 
-    @SubscribeEvent
     public void clientSetup(FMLClientSetupEvent event) {
         DebuggingHooks.runWithTracing(LogFlag.CORE, "clientSetup(FMLClientSetupEvent)", LOGGER, () -> {
             // Intentionally blank hook for future use


### PR DESCRIPTION
## Summary
- register common and client setup hooks on the mod event bus during construction
- reuse the captured mod event bus when registering deferred items and remove the unused ModEventSubscriber helper

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693eefb92ce0833181e89bafdba9c12f)