### PR TITLE
Depend on HellasControl from GitHub

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,12 +85,11 @@ repositories {
 
 
 dependencies {
-    // Use the correctly cased JitPack coordinate for HellasControl
-    compileOnly fg.deobf('com.github.xSasakiHaise:HellasControl:2.0.0')
     minecraft "net.minecraftforge:forge:1.16.5-36.2.42"
 
     implementation fg.deobf("pixelmon:Pixelmon-1.16.5-9.1.12-universal:9.1.12")
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
+    compileOnly fg.deobf('com.github.xSasakiHaise:hellascontrol:master-SNAPSHOT')
 
 }
 

--- a/src/main/java/com/xsasakihaise/hellasforms/HellasForms.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/HellasForms.java
@@ -16,9 +16,10 @@ import com.xsasakihaise.hellasforms.items.consumables.EvMaximizerItem;
 import com.xsasakihaise.hellasforms.items.consumables.ExperienceCandyItem;
 import com.xsasakihaise.hellasforms.items.consumables.FormChangeTicketItem;
 import com.xsasakihaise.hellasforms.items.consumables.RustedBottleCapItem;
-import com.xsasakihaise.hellasforms.items.heldItems.EeveeoliteItem;
 import com.xsasakihaise.hellasforms.diagnostics.DebuggingHooks;
 import com.xsasakihaise.hellasforms.diagnostics.LogFlag;
+import com.xsasakihaise.hellascontrol.HellasControl;
+import com.xsasakihaise.hellasforms.items.heldItems.EeveeoliteItem;
 import com.xsasakihaise.hellasforms.listener.GrowthSpawningListener;
 import com.xsasakihaise.hellasforms.listener.ReturnItemsListener;
 import net.minecraft.item.Item;
@@ -33,12 +34,12 @@ import net.minecraftforge.fml.event.server.FMLServerStartedEvent;
 import net.minecraftforge.fml.event.server.FMLServerStoppedEvent;
 import net.minecraftforge.fml.event.server.FMLServerStoppingEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import com.pixelmonmod.pixelmon.api.pokemon.stats.BattleStatsType;
-import com.xsasakihaise.hellascontrol.api.CoreCheck;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.loading.FMLEnvironment;
 
@@ -70,10 +71,15 @@ public class HellasForms {
      * and registers every runtime component that belongs to the mod.
      */
     public HellasForms() {
-        DebuggingHooks.runWithTracing(LogFlag.API, "CoreCheck.verifyCoreLoaded()", LOGGER, CoreCheck::verifyCoreLoaded);
+        DebuggingHooks.runWithTracing(LogFlag.API, "verify HellasControl is present", LOGGER, () -> {
+            if (!ModList.get().isLoaded(HellasControl.MODID)) {
+                throw new IllegalStateException("HellasControl core mod missing!");
+            }
+        });
         if (FMLEnvironment.dist == Dist.DEDICATED_SERVER) {
-            DebuggingHooks.runWithTracing(LogFlag.API, "CoreCheck.verifyEntitled(\"" + ENTITLEMENT_KEY + "\")", LOGGER,
-                    () -> CoreCheck.verifyEntitled(ENTITLEMENT_KEY));
+            DebuggingHooks.runWithTracing(LogFlag.API,
+                    "HellasControl.requireEntitlement(\"" + ENTITLEMENT_KEY + "\")", LOGGER,
+                    () -> HellasControl.requireEntitlement(ENTITLEMENT_KEY));
         }
         DebuggingHooks.initialize(LOGGER);
         DebuggingHooks.runWithTracing(LogFlag.CORE, "HellasForms::<init>", LOGGER, () -> {


### PR DESCRIPTION
## Summary
- replace the local HellasControl verifier with the official API
- add a compile-only HellasControl dependency from the GitHub repository via JitPack
- invoke HellasControl entitlement checks directly during mod startup

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ef6aa314c8331923b936fca51999b)