### PR TITLE
Allow flexible Pixelmon and HellasControl local jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,16 +76,41 @@ repositories {
         name = 'sponge'
         url = 'https://repo.spongepowered.org/maven'
     }
-    flatDir { dirs 'libs' }
 }
+
+def pixelmonJarName = (project.findProperty("pixelmonJarName") ?: "Pixelmon-1.16.5-9.1.12-universal.jar").toString()
+def pixelmonJar = file("libs/${pixelmonJarName}")
+if (!pixelmonJar.exists()) {
+    def pixelmonMatches = fileTree("libs").matching { include "Pixelmon-1.16.5-9.1.1*-universal.jar" }.files.toList()
+    if (!pixelmonMatches.isEmpty()) {
+        pixelmonJar = pixelmonMatches.sort { it.name }.last()
+    }
+}
+if (!pixelmonJar.exists()) {
+    throw new GradleException("Missing Pixelmon jar at libs/${pixelmonJarName}. You can also place any Pixelmon-1.16.5-9.1.1*-universal.jar in libs/ or set -PpixelmonJarName=... to override.")
+}
+
+def hellasControlLocalJars = fileTree("libs").matching { include "*hellascontrol*.jar" }.files.toList()
+def hellasControlLocalJar = hellasControlLocalJars.isEmpty() ? null : hellasControlLocalJars.sort { it.name }.last()
+def useHellasControlLocalJar = hellasControlLocalJar != null && hellasControlLocalJar.exists()
 
 
 dependencies {
     minecraft "net.minecraftforge:forge:1.16.5-36.2.42"
 
-    implementation fg.deobf(name: 'Pixelmon-1.16.5-9.1.12-universal')
+    // Place Pixelmon at libs/Pixelmon-1.16.5-9.1.12-universal.jar (not tracked in git).
+    // You can override the name with -PpixelmonJarName=... or drop a Pixelmon-1.16.5-9.1.1*-universal.jar into libs/.
+    implementation fg.deobf(files(pixelmonJar))
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
-    compileOnly fg.deobf('com.github.xSasakiHaise:HellasControl:master-SNAPSHOT')
+    // If you have hellascontrol checked out next to this repo, includeBuild("../hellascontrol") will be used.
+    // Alternatively, drop any *hellascontrol*.jar into libs/ to use that directly.
+    if (useHellasControlLocalJar) {
+        compileOnly fg.deobf(files(hellasControlLocalJar))
+    } else if (file("../hellascontrol").exists()) {
+        compileOnly fg.deobf("com.xsasakihaise.hellascontrol:hellascontrol:2.0.0")
+    } else {
+        compileOnly fg.deobf("com.github.xSasakiHaise:hellascontrol:master-SNAPSHOT")
+    }
 
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,3 +13,8 @@ pluginManagement {
 plugins {
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.7.0'
 }
+
+def hellasControlDir = file("../hellascontrol")
+if (hellasControlDir.exists()) {
+    includeBuild(hellasControlDir)
+}


### PR DESCRIPTION
### Motivation

- Make local development easier by allowing non-exact Pixelmon jar filenames and local HellasControl artifacts instead of requiring remote resolution. 
- Provide a simple override for Pixelmon jar name to support different 9.1.1x builds and debugging variations. 
- Prefer a local HellasControl jar or composite build checkout before falling back to JitPack to improve reliability for local development. 

### Description

- Add a `-PpixelmonJarName=...` property and logic to pick a Pixelmon jar from `libs/` matching `Pixelmon-1.16.5-9.1.1*-universal.jar` when the explicit name is missing and fail with a clear error if none found. 
- Accept any `*hellascontrol*.jar` in `libs/` (choose the lexically last file) and use it via `fg.deobf(files(...))` before checking `../hellascontrol` or JitPack coordinates. 
- Add `includeBuild(../hellascontrol)` in `settings.gradle` when `../hellascontrol` exists so the composite build is available. 
- Update inline comments and switch the Pixelmon dependency to `implementation fg.deobf(files(pixelmonJar))` for local-jar deobfuscation. 

### Testing

- Ran `./gradlew --no-daemon clean build`, which failed with the expected error message about the missing Pixelmon jar (no local jar present). 
- Ran `./gradlew --no-daemon dependencies --configuration compileClasspath`, which likewise failed with the same missing Pixelmon jar error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e889883483318afa63fbd4ee3314)