### PR TITLE
Make Pixelmon and hellascontrol jar detection case-insensitive

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,16 +81,20 @@ repositories {
 def pixelmonJarName = (project.findProperty("pixelmonJarName") ?: "Pixelmon-1.16.5-9.1.12-universal.jar").toString()
 def pixelmonJar = file("libs/${pixelmonJarName}")
 if (!pixelmonJar.exists()) {
-    def pixelmonMatches = fileTree("libs").matching { include "Pixelmon-1.16.5-9.1.1*-universal.jar" }.files.toList()
+    def pixelmonMatches = fileTree("libs").files
+            .findAll { it.name.toLowerCase().contains("pixelmon") && it.name.toLowerCase().endsWith(".jar") }
+            .toList()
     if (!pixelmonMatches.isEmpty()) {
         pixelmonJar = pixelmonMatches.sort { it.name }.last()
     }
 }
 if (!pixelmonJar.exists()) {
-    throw new GradleException("Missing Pixelmon jar at libs/${pixelmonJarName}. You can also place any Pixelmon-1.16.5-9.1.1*-universal.jar in libs/ or set -PpixelmonJarName=... to override.")
+    throw new GradleException("Missing Pixelmon jar at libs/${pixelmonJarName}. You can also place any *pixelmon*.jar in libs/ or set -PpixelmonJarName=... to override.")
 }
 
-def hellasControlLocalJars = fileTree("libs").matching { include "*hellascontrol*.jar" }.files.toList()
+def hellasControlLocalJars = fileTree("libs").files
+        .findAll { it.name.toLowerCase().contains("hellascontrol") && it.name.toLowerCase().endsWith(".jar") }
+        .toList()
 def hellasControlLocalJar = hellasControlLocalJars.isEmpty() ? null : hellasControlLocalJars.sort { it.name }.last()
 def useHellasControlLocalJar = hellasControlLocalJar != null && hellasControlLocalJar.exists()
 


### PR DESCRIPTION
### Motivation
- Jar detection was too strict and failed to find Pixelmon and hellascontrol jars with different case or naming variants in `libs/`.
- The intent is to accept any Pixelmon or hellascontrol jar placed in `libs/` regardless of case when the default name is missing.

### Description
- Replaced strict include patterns with case-insensitive file name searches using `.findAll { it.name.toLowerCase().contains("pixelmon") && it.name.toLowerCase().endsWith(".jar") }` for Pixelmon fallback in `build.gradle`.
- Applied the same case-insensitive matching for hellascontrol with `.findAll { it.name.toLowerCase().contains("hellascontrol") && it.name.toLowerCase().endsWith(".jar") }` and selection of the last sorted match.
- Updated the missing-Pixelmon error message to reference any `*pixelmon*.jar` and document `-PpixelmonJarName=...` as an override.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949f24b5bcc8331be8e0e88f69c44ad)