### PR TITLE
Fix form ticket checks and item registration

### DIFF
--- a/src/main/java/com/xsasakihaise/hellasforms/HellasForms.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/HellasForms.java
@@ -180,6 +180,7 @@ public class HellasForms {
 
             // Regular Forge items defined by this mod (eggs, ores, quest tokens).
             DebuggingHooks.runWithTracing(LogFlag.ITEMS, "registerHellasItems", LOGGER, () -> {
+                IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
                 ITEMS.register("wild-egg", PokemonEggItem::new);
                 ITEMS.register("hellasian-egg", PokemonEggItem::new);
                 ITEMS.register("odd-looking-egg", PokemonEggItem::new);

--- a/src/main/java/com/xsasakihaise/hellasforms/items/consumables/FormChangeTicketItem.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/items/consumables/FormChangeTicketItem.java
@@ -1,7 +1,6 @@
 package com.xsasakihaise.hellasforms.items.consumables;
 
 import com.pixelmonmod.pixelmon.api.pokemon.Pokemon;
-import com.pixelmonmod.pixelmon.api.pokemon.species.form.Form;
 import com.pixelmonmod.pixelmon.entities.pixelmon.PixelmonEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
@@ -26,8 +25,7 @@ public class FormChangeTicketItem extends PokemonInteractItem {
 
     @Override
     protected boolean applyEffect(PlayerEntity player, Pokemon pokemon, PixelmonEntity entity, ItemStack stack) {
-        Form form = pokemon.getSpecies().getForm(targetForm);
-        boolean hasTargetForm = form != null && form.getName().equalsIgnoreCase(targetForm);
+        boolean hasTargetForm = pokemon.getSpecies().getForm(targetForm) != null;
         if (!hasTargetForm || pokemon.getForm().isForm(targetForm)) {
             return false;
         }
@@ -44,8 +42,7 @@ public class FormChangeTicketItem extends PokemonInteractItem {
 
     @Override
     protected ITextComponent getFailureMessage(Pokemon pokemon) {
-        Form form = pokemon.getSpecies().getForm(targetForm);
-        if (form == null || !form.getName().equalsIgnoreCase(targetForm)) {
+        if (pokemon.getSpecies().getForm(targetForm) == null) {
             return new TranslationTextComponent("item.hellasforms.form_change.missing", pokemon.getDisplayName(), targetForm);
         }
         if (pokemon.getForm().isForm(targetForm)) {


### PR DESCRIPTION
### Motivation
- Resolve compilation errors caused by referencing the `com.pixelmonmod.pixelmon.api.pokemon.species.form.Form` type that is not available. 
- Fix an undefined `modEventBus` reference during Forge `ITEMS` registration so items are properly registered on the mod event bus. 
- Make form-change ticket logic robust to missing forms by avoiding direct `Form` usage. 
- Prevent tickets from being consumed when the target form is missing or the Pokémon is already in the target form. 

### Description
- Removed the `Form` import and replaced checks with `pokemon.getSpecies().getForm(targetForm) != null` null checks in `FormChangeTicketItem`. 
- Updated failure message logic to use `pokemon.getSpecies().getForm(targetForm) == null` when reporting missing forms. 
- Added `IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();` inside the `registerHellasItems` block and call `ITEMS.register(modEventBus);` in `HellasForms`. 
- Changes applied to `src/main/java/com/xsasakihaise/hellasforms/items/consumables/FormChangeTicketItem.java` and `src/main/java/com/xsasakihaise/hellasforms/HellasForms.java`. 

### Testing
- No automated tests were run after these changes. 
- No test results to report.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949f502c9788331b47b85b9500f265a)