### PR TITLE
Fix logger access in setup and interaction classes

### DIFF
--- a/src/main/java/com/xsasakihaise/hellasforms/HellasFormsSetup.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/HellasFormsSetup.java
@@ -26,7 +26,7 @@ public final class HellasFormsSetup {
         if (tryRegister(interaction, "com.pixelmonmod.pixelmon.api.interactions.InteractionController", "registerInteraction")) {
             return;
         }
-        HellasForms.LOGGER.error("Unable to register Pixelmon interaction {} - no compatible registry methods found", interaction.getClass().getName());
+        HellasForms.getLogger().error("Unable to register Pixelmon interaction {} - no compatible registry methods found", interaction.getClass().getName());
     }
 
     @SuppressWarnings("unchecked")
@@ -54,10 +54,10 @@ public final class HellasFormsSetup {
                 return false;
             }
             method.invoke(null, argument);
-            HellasForms.LOGGER.debug("Registered Pixelmon interaction {} via {}#{}", interaction.getClass().getName(), className, methodName);
+            HellasForms.getLogger().debug("Registered Pixelmon interaction {} via {}#{}", interaction.getClass().getName(), className, methodName);
             return true;
         } catch (final ReflectiveOperationException ex) {
-            HellasForms.LOGGER.debug("Failed to register Pixelmon interaction {} via {}#{}", interaction.getClass().getName(), className, methodName, ex);
+            HellasForms.getLogger().debug("Failed to register Pixelmon interaction {} via {}#{}", interaction.getClass().getName(), className, methodName, ex);
             return false;
         }
     }

--- a/src/main/java/com/xsasakihaise/hellasforms/interactions/InteractionBottleCap.java
+++ b/src/main/java/com/xsasakihaise/hellasforms/interactions/InteractionBottleCap.java
@@ -92,7 +92,7 @@ public class InteractionBottleCap implements IInteraction {
             try {
                 return Pokemon.class.getMethod("getOwnerPlayerUUID");
             } catch (final NoSuchMethodException fallback) {
-                HellasForms.LOGGER.error("Failed to find a compatible Pokemon owner UUID accessor", fallback);
+                HellasForms.getLogger().error("Failed to find a compatible Pokemon owner UUID accessor", fallback);
                 return null;
             }
         }
@@ -105,7 +105,7 @@ public class InteractionBottleCap implements IInteraction {
         try {
             return (UUID) OWNER_UUID_METHOD.invoke(pokemon);
         } catch (final IllegalAccessException | InvocationTargetException e) {
-            HellasForms.LOGGER.error("Failed to invoke Pokemon owner UUID accessor", e);
+            HellasForms.getLogger().error("Failed to invoke Pokemon owner UUID accessor", e);
             return null;
         }
     }


### PR DESCRIPTION
### Motivation

- The project failed to compile because several classes accessed the `LOGGER` field directly which is declared private in `HellasForms`. 
- The change replaces direct field access with the public accessor to restore compatibility with the `HellasForms` visibility rules. 

### Description

- Replaced `HellasForms.LOGGER` with `HellasForms.getLogger()` in `src/main/java/com/xsasakihaise/hellasforms/HellasFormsSetup.java` to fix registration logging. 
- Replaced `HellasForms.LOGGER` with `HellasForms.getLogger()` in `src/main/java/com/xsasakihaise/hellasforms/interactions/InteractionBottleCap.java` for owner-UUID accessor logging. 
- Added and committed the two source changes with the message `Fix logger access in setup interactions`.

### Testing

- A Gradle build was previously executed and failed with compilation errors referencing private `LOGGER` access. 
- No automated tests or builds were run after the fixes were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950d6b5a0a08331835d5d3c142ea6ee)