### PR TITLE
Update build setup for MC 1.21.1 and Pixelmon 9.3 artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ sourceSets.main.resources { srcDir 'src/generated/resources' }
 
 repositories {
     mavenCentral()
+    maven { url = 'https://maven.neoforged.net/releases' }
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     maven { url 'https://repo.lucko.me/' }
     maven { url = "https://repo.aikar.co/content/groups/aikar/" }
@@ -78,18 +79,30 @@ repositories {
     }
 }
 
-def pixelmonJarName = (project.findProperty("pixelmonJarName") ?: "Pixelmon-1.21.1-9.1.13-universal.jar").toString()
-def pixelmonJar = file("libs/${pixelmonJarName}")
-if (!pixelmonJar.exists()) {
-    def pixelmonMatches = fileTree("libs").files
-            .findAll { it.name.toLowerCase().contains("pixelmon") && it.name.toLowerCase().endsWith(".jar") }
-            .toList()
+def pixelmonArtifactName = (project.findProperty("pixelmonArtifactName") ?: "Pixelmon-1.21.1-9.3.13-universal").toString()
+def pixelmonArtifact = file("libs/${pixelmonArtifactName}")
+if (!pixelmonArtifact.exists()) {
+    def pixelmonMatches = file("libs").listFiles()?.findAll {
+        def name = it.name.toLowerCase()
+        name.contains("pixelmon") && (name.endsWith(".jar") || it.directory)
+    }?.toList() ?: []
     if (!pixelmonMatches.isEmpty()) {
-        pixelmonJar = pixelmonMatches.sort { it.name }.last()
+        pixelmonArtifact = pixelmonMatches.sort { it.name }.last()
     }
 }
-if (!pixelmonJar.exists()) {
-    throw new GradleException("Missing Pixelmon jar at libs/${pixelmonJarName}. You can also place any *pixelmon*.jar in libs/ or set -PpixelmonJarName=... to override.")
+if (!pixelmonArtifact.exists()) {
+    throw new GradleException("Missing Pixelmon artifact at libs/${pixelmonArtifactName}. You can also place any *pixelmon*.jar (or extracted Pixelmon directory) in libs/ or set -PpixelmonArtifactName=... to override.")
+}
+
+if (pixelmonArtifact.isDirectory()) {
+    def pixelmonJarCache = file("${buildDir}/tmp/pixelmon/${pixelmonArtifact.name}.jar")
+    if (!pixelmonJarCache.exists() || pixelmonJarCache.lastModified() < pixelmonArtifact.lastModified()) {
+        pixelmonJarCache.parentFile.mkdirs()
+        ant.zip(destfile: pixelmonJarCache) {
+            fileset(dir: pixelmonArtifact)
+        }
+    }
+    pixelmonArtifact = pixelmonJarCache
 }
 
 def hellasControlLocalJars = fileTree("libs").files
@@ -102,18 +115,18 @@ def useHellasControlLocalJar = hellasControlLocalJar != null && hellasControlLoc
 dependencies {
     minecraft "net.neoforged:neoforge:${forge_version}"
 
-    // Place Pixelmon at libs/Pixelmon-1.21.1-9.1.12-universal.jar (not tracked in git).
-    // You can override the name with -PpixelmonJarName=... or drop a Pixelmon-1.21.1-9.1.1*-universal.jar into libs/.
-    implementation fg.deobf(files(pixelmonJar))
+    // Place Pixelmon under libs/ (jar or extracted directory, not tracked in git).
+    // You can override with -PpixelmonArtifactName=... or drop any Pixelmon artifact in libs/.
+    implementation files(pixelmonArtifact)
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
     // If you have hellascontrol checked out next to this repo, includeBuild("../hellascontrol") will be used.
     // Alternatively, drop any *hellascontrol*.jar into libs/ to use that directly.
     if (useHellasControlLocalJar) {
-        compileOnly fg.deobf(files(hellasControlLocalJar))
+        compileOnly files(hellasControlLocalJar)
     } else if (file("../hellascontrol").exists()) {
-        compileOnly fg.deobf("com.xsasakihaise.hellascontrol:hellascontrol:2.0.0")
+        compileOnly "com.xsasakihaise.hellascontrol:hellascontrol:2.0.0"
     } else {
-        compileOnly fg.deobf("com.github.xSasakiHaise:hellascontrol:master-SNAPSHOT")
+        compileOnly "com.github.xSasakiHaise:hellascontrol:master-SNAPSHOT"
     }
 
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Motivation
- Ensure the project builds against Minecraft `1.21.1` and the newer Pixelmon 9.3 artifacts used locally. 
- Make the Pixelmon dependency resolution more flexible so developers can drop either a `.jar` or an extracted Pixelmon directory into `libs/`. 
- Keep the Gradle tooling compatible with modern JDKs by updating the wrapper.

### Description
- Added the NeoForged Maven repository `https://maven.neoforged.net/releases` so `neoforge` artifacts resolve for MC `1.21.1`. 
- Replaced the old `pixelmonJarName` logic with `pixelmonArtifactName` defaulting to `Pixelmon-1.21.1-9.3.13-universal` and updated discovery to accept either a `.jar` or an extracted Pixelmon directory. 
- When an extracted Pixelmon directory is detected, auto-package it into a temporary jar under `build/tmp/pixelmon/` and use that artifact for the dependency. 
- Switched file-based dependencies for Pixelmon and local HellasControl jars to use `files(...)` and simplified `compileOnly` coordinates to avoid `fg.deobf(...)` wrapping. 
- Upgraded the Gradle wrapper from `8.4` to `8.14.3` in `gradle/wrapper/gradle-wrapper.properties`.

### Testing
- Verified the JDK version with `java -version` and targeted Java 21 for validation. 
- Ran `export JAVA_HOME=... && ./gradlew compileJava -x test` (Java 25) which initially failed due to unsupported class file major version, so the environment was switched to Java 21. 
- Ran `export JAVA_HOME=$HOME/.local/share/mise/installs/java/21.0.2 && ./gradlew compileJava -x test` which progressed but failed during project configuration with `java.lang.IllegalStateException: Expected BEGIN_ARRAY but was STRING at line 1 column 75 path $.ats`, indicating a ForgeGradle/userdev metadata parsing issue unrelated to the dependency path changes. 
- No compilation of project sources completed due to the configuration-level failure described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cf1c9a4548331810a2bee4646c3a4)